### PR TITLE
feat(admin/pamphlets): add inline preview and text editing

### DIFF
--- a/templates/admin/pamphlets.html
+++ b/templates/admin/pamphlets.html
@@ -10,26 +10,45 @@
     }
     *{box-sizing:border-box}
     body{font-family:'Segoe UI','メイリオ',sans-serif;background:var(--bg);margin:0}
-    .container{background:#fff;padding:26px 28px;margin:38px auto;max-width:1100px;border-radius:17px;box-shadow:0 4px 20px #b7d3e04d}
+    .container{background:#fff;padding:26px 28px;margin:38px auto;max-width:1180px;border-radius:17px;box-shadow:0 4px 20px #b7d3e04d}
     h1{margin:0 0 18px;font-size:22px}
     table{width:100%;border-collapse:collapse}
     th,td{padding:8px 10px;border-bottom:1px solid var(--line);font-size:14px}
     th{text-align:left;background:#f2f5fb}
-    td.actions{text-align:center}
+    td.actions{text-align:center;white-space:nowrap}
     .nav{margin-bottom:18px}
     .nav a{margin-right:16px;font-size:1em;color:var(--brand);text-decoration:none;font-weight:500}
     .nav a:hover{text-decoration:underline}
     form.inline{display:inline}
     .grid{display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap}
-    .panel{flex:1 1 320px}
+    .panel{flex:1 1 520px;background:#fff}
     .panel h2{font-size:18px;margin:16px 0 12px}
-    .btn{display:inline-flex;align-items:center;justify-content:center;height:32px;padding:0 12px;border-radius:6px;border:1px solid var(--line);background:#fff;cursor:pointer}
+    .panel-body{padding:0 6px 20px}
+    .panel-actions{margin-top:24px;padding-top:6px;border-top:1px solid var(--line)}
+    .btn{display:inline-flex;align-items:center;justify-content:center;height:32px;padding:0 12px;border-radius:6px;border:1px solid var(--line);background:#fff;cursor:pointer;font-size:13px}
     .btn:hover{background:#f9fafb}
     .btn.danger{color:#fff;background:var(--danger);border-color:var(--danger)}
+    .btn.primary{background:var(--brand);color:#fff;border-color:var(--brand)}
     .form-grid{display:grid;gap:8px}
     label{font-weight:600;margin-right:8px}
     select{height:32px;border-radius:6px;border:1px solid var(--line);padding:0 8px}
     input[type="file"]{font-size:14px}
+    .monospace{font-family:'SFMono-Regular','Consolas','Menlo','Courier New',monospace}
+    .file-link{color:inherit;text-decoration:none}
+    .file-link:hover{text-decoration:underline;color:var(--brand)}
+    tr.is-active{background:#eef6ff}
+    tr.is-active td{border-bottom-color:#d0e6ff}
+    .preview-card{padding:14px 16px;border:1px solid var(--line);border-radius:12px;background:#f9fbfe}
+    #preview-info{font-size:14px;color:#0f172a}
+    #preview-info strong{display:block;font-size:16px;margin-bottom:6px;word-break:break-all}
+    #preview-text{white-space:pre-wrap;word-break:break-word;max-height:480px;overflow:auto;margin:12px 0 0;padding:12px;border:1px solid var(--line);border-radius:8px;background:#fff}
+    #preview-status{color:var(--muted);font-size:13px;margin-top:8px}
+    .muted{color:var(--muted)}
+    .actions .btn{margin:0 2px}
+    @media (max-width: 880px){
+      .panel{flex:1 1 100%}
+      #preview-text{max-height:360px}
+    }
     @media (max-width: 720px){
       .container{margin:18px auto;padding:20px 16px}
     }
@@ -51,54 +70,168 @@
 
     <div class="grid">
       <section class="panel">
-        <h2>ファイル一覧（{{ cities[city] }}）</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>名前</th>
-              <th style="text-align:right;">サイズ</th>
-              <th>更新日時</th>
-              <th style="text-align:center;">操作</th>
-            </tr>
-          </thead>
-          <tbody>
-          {% for f in files %}
-            <tr>
-              <td>{{ f.name }}</td>
-              <td style="text-align:right;">{{ (f.size / 1024)|round(1) }} KB</td>
-              <td>{{ f.mtime.strftime('%Y-%m-%d %H:%M') }}</td>
-              <td class="actions">
-                <form method="post" action="{{ url_for('pamphlets_admin.pamphlets_delete') }}" class="inline">
-                  <input type="hidden" name="city" value="{{ city }}">
-                  <input type="hidden" name="name" value="{{ f.name }}">
-                  <button type="submit" class="btn danger">削除</button>
-                </form>
-              </td>
-            </tr>
-          {% else %}
-            <tr>
-              <td colspan="4" style="text-align:center;">ファイルがありません</td>
-            </tr>
-          {% endfor %}
-          </tbody>
-        </table>
+        <div class="panel-body">
+          <h2>ファイル一覧（{{ cities[city] }}）</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>名前</th>
+                <th style="text-align:right;">サイズ</th>
+                <th>更新日時</th>
+                <th style="text-align:center;">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for f in files %}
+              <tr data-name="{{ f.name }}">
+                <td>
+                  <a href="#" class="file-link" data-name="{{ f.name }}">{{ f.name }}</a>
+                </td>
+                <td style="text-align:right;">{{ (f.size / 1024)|round(1) }} KB</td>
+                <td>{{ f.mtime.strftime('%Y-%m-%d %H:%M') }}</td>
+                <td class="actions">
+                  <a class="btn" href="{{ url_for('pamphlets_admin.pamphlets_edit', city=city, name=f.name) }}">編集</a>
+                  <form method="post" action="{{ url_for('pamphlets_admin.pamphlets_delete') }}" class="inline" style="display:inline-block;">
+                    <input type="hidden" name="city" value="{{ city }}">
+                    <input type="hidden" name="name" value="{{ f.name }}">
+                    <button type="submit" class="btn danger">削除</button>
+                  </form>
+                </td>
+              </tr>
+            {% else %}
+              <tr>
+                <td colspan="4" style="text-align:center;">ファイルがありません</td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+
+          <div class="panel-actions">
+            <h2>アップロード</h2>
+            <form method="post" enctype="multipart/form-data" action="{{ url_for('pamphlets_admin.pamphlets_upload') }}" class="form-grid">
+              <input type="hidden" name="city" value="{{ city }}">
+              <input type="file" name="file" accept=".txt" required>
+              <button type="submit" class="btn">アップロード</button>
+            </form>
+
+            <h2>インデックス</h2>
+            <form method="post" action="{{ url_for('pamphlets_admin.pamphlets_reindex') }}">
+              <input type="hidden" name="city" value="{{ city }}">
+              <button type="submit" class="btn">実行</button>
+            </form>
+          </div>
+        </div>
       </section>
 
-      <section class="panel" style="max-width:360px;">
-        <h2>アップロード</h2>
-        <form method="post" enctype="multipart/form-data" action="{{ url_for('pamphlets_admin.pamphlets_upload') }}" class="form-grid">
-          <input type="hidden" name="city" value="{{ city }}">
-          <input type="file" name="file" accept=".txt" required>
-          <button type="submit" class="btn">アップロード</button>
-        </form>
-
-        <h2>再インデックス</h2>
-        <form method="post" action="{{ url_for('pamphlets_admin.pamphlets_reindex') }}">
-          <input type="hidden" name="city" value="{{ city }}">
-          <button type="submit" class="btn">実行</button>
-        </form>
+      <section class="panel" style="flex:1 1 380px;">
+        <div class="panel-body">
+          <h2>プレビュー</h2>
+          <div class="preview-card">
+            <div id="preview-info" class="muted">ファイルを選択してください。</div>
+            <div id="preview-actions" style="margin-top:12px;display:none;gap:8px;align-items:center;">
+              <a id="preview-edit" class="btn primary" href="#">全文を開く（編集）</a>
+            </div>
+            <pre id="preview-text" class="monospace muted">(ここにプレビューが表示されます)</pre>
+            <div id="preview-status"></div>
+          </div>
+        </div>
       </section>
     </div>
   </div>
+  <script>
+    const city = {{ city|tojson }};
+    const viewUrl = {{ url_for('pamphlets_admin.pamphlets_view')|tojson }};
+    const editBase = {{ url_for('pamphlets_admin.pamphlets_edit')|tojson }};
+    const previewText = document.getElementById('preview-text');
+    const previewInfo = document.getElementById('preview-info');
+    const previewStatus = document.getElementById('preview-status');
+    const previewEdit = document.getElementById('preview-edit');
+    const previewActions = document.getElementById('preview-actions');
+    const rows = document.querySelectorAll('tbody tr[data-name]');
+
+    function setActiveRow(name) {
+      rows.forEach((row) => {
+        if (row.dataset.name === name) {
+          row.classList.add('is-active');
+        } else {
+          row.classList.remove('is-active');
+        }
+      });
+    }
+
+    function formatBytes(bytes) {
+      if (bytes < 1024) {
+        return bytes + ' B';
+      }
+      const kb = bytes / 1024;
+      if (kb < 1024) {
+        return kb.toFixed(1) + ' KB';
+      }
+      const mb = kb / 1024;
+      return mb.toFixed(2) + ' MB';
+    }
+
+    function showLoading(name) {
+      setActiveRow(name);
+      previewInfo.innerHTML = '<strong>' + name + '</strong><span class="muted">読み込み中...</span>';
+      previewText.textContent = '';
+      previewText.classList.add('muted');
+      previewStatus.textContent = '';
+      previewActions.style.display = 'none';
+    }
+
+    function showError(message) {
+      previewInfo.innerHTML = '<span class="muted">エラーが発生しました。</span>';
+      previewText.textContent = '';
+      previewText.classList.add('muted');
+      previewStatus.textContent = message;
+      previewActions.style.display = 'none';
+    }
+
+    function updatePreview(data) {
+      previewInfo.innerHTML = '<strong>' + data.name + '</strong>' +
+        '<span class="muted">' + formatBytes(data.size) + ' ／ 更新: ' +
+        new Date(data.mtime * 1000).toLocaleString('ja-JP') + '</span>';
+      previewText.textContent = data.text;
+      previewText.classList.remove('muted');
+      previewStatus.textContent = data.truncated ? '200KB までを表示しています。全文は「編集」で確認してください。' : '';
+      if (data.truncated) {
+        previewActions.style.display = 'flex';
+        previewEdit.href = editBase + '?city=' + encodeURIComponent(city) + '&name=' + encodeURIComponent(data.name);
+      } else {
+        previewActions.style.display = 'none';
+      }
+    }
+
+    function loadPreview(name) {
+      if (!name) return;
+      showLoading(name);
+      fetch(viewUrl + '?city=' + encodeURIComponent(city) + '&name=' + encodeURIComponent(name), {
+        headers: {'Accept': 'application/json'}
+      })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error('プレビューの取得に失敗しました。');
+          }
+          return response.json();
+        })
+        .then((data) => {
+          if (data.error) {
+            throw new Error(data.error);
+          }
+          updatePreview(data);
+        })
+        .catch((error) => {
+          showError(error.message);
+        });
+    }
+
+    document.querySelectorAll('.file-link').forEach((link) => {
+      link.addEventListener('click', (event) => {
+        event.preventDefault();
+        loadPreview(link.dataset.name);
+      });
+    });
+  </script>
 </body>
 </html>

--- a/templates/admin/pamphlets_edit.html
+++ b/templates/admin/pamphlets_edit.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <title>パンフレット編集 - {{ name }}</title>
+  <style>
+    :root{
+      --bg:#f6faf9; --panel:#fff; --muted:#64748b; --line:#e5e7eb; --brand:#2a8ed8; --danger:#dc2626;
+    }
+    *{box-sizing:border-box}
+    body{font-family:'Segoe UI','メイリオ',sans-serif;background:var(--bg);margin:0}
+    .container{background:#fff;padding:26px 28px;margin:38px auto;max-width:960px;border-radius:17px;box-shadow:0 4px 20px #b7d3e04d}
+    h1{margin:0 0 18px;font-size:22px}
+    .info{color:#0f172a;margin-bottom:16px;font-size:14px}
+    .info span{margin-right:12px}
+    .muted{color:var(--muted)}
+    textarea{width:100%;border:1px solid var(--line);border-radius:10px;padding:12px;font-size:14px;resize:vertical;min-height:320px;background:#fdfdfd}
+    textarea:focus{outline:2px solid rgba(42,142,216,.25)}
+    .monospace{font-family:'SFMono-Regular','Consolas','Menlo','Courier New',monospace}
+    .actions{margin-top:18px;display:flex;gap:12px;flex-wrap:wrap}
+    .btn{display:inline-flex;align-items:center;justify-content:center;height:36px;padding:0 16px;border-radius:8px;border:1px solid var(--line);background:#fff;cursor:pointer;font-size:14px;text-decoration:none;color:#0f172a}
+    .btn:hover{background:#f9fafb}
+    .btn.primary{background:var(--brand);color:#fff;border-color:var(--brand)}
+    .btn.secondary{background:#f3f4f6}
+    .btn.danger{background:var(--danger);color:#fff;border-color:var(--danger)}
+    .alert{padding:12px 14px;border-radius:8px;margin-bottom:18px;font-size:14px}
+    .alert.success{background:#dcfce7;color:#14532d}
+    .alert.danger{background:#fee2e2;color:#991b1b}
+    .alert.warning{background:#fef3c7;color:#92400e}
+    .alert.info{background:#e0f2fe;color:#075985}
+    form.inline{display:inline}
+    @media (max-width: 720px){
+      .container{margin:18px auto;padding:22px 16px}
+      textarea{min-height:260px}
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    {% include '_admin_nav.html' %}
+    <h1>{{ cities[city] }} / {{ name }}</h1>
+
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert {{ category }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    <div class="info">
+      <span>サイズ: {{ (size / 1024)|round(1) }} KB</span>
+      <span>最終更新: {{ mtime.strftime('%Y-%m-%d %H:%M:%S') }}</span>
+      <span class="muted">（{{ (max_edit_bytes / 1024 / 1024)|round(1) }}MB まで編集可能）</span>
+    </div>
+
+    {% if too_large %}
+      <div class="alert warning">ファイルサイズが大きいためこの画面から編集できません。ダウンロードしてオフラインで編集し、アップロードしてください。</div>
+      <div class="actions">
+        <a class="btn secondary" href="{{ url_for('pamphlets_admin.pamphlets_index', city=city) }}">一覧へ戻る</a>
+        <a class="btn" href="{{ url_for('pamphlets_admin.pamphlets_download', city=city, name=name) }}">ダウンロード</a>
+      </div>
+    {% else %}
+      <form method="post" action="{{ url_for('pamphlets_admin.pamphlets_save') }}">
+        <input type="hidden" name="city" value="{{ city }}">
+        <input type="hidden" name="name" value="{{ name }}">
+        <input type="hidden" name="expected_mtime" value="{{ expected_mtime }}">
+        <textarea name="content" rows="28" spellcheck="false" class="monospace">{{ text or '' }}</textarea>
+        <div class="actions">
+          <button type="submit" class="btn primary">保存</button>
+          <a class="btn secondary" href="{{ url_for('pamphlets_admin.pamphlets_index', city=city) }}">一覧へ戻る</a>
+          <a class="btn" href="{{ url_for('pamphlets_admin.pamphlets_download', city=city, name=name) }}">ダウンロード</a>
+        </div>
+      </form>
+    {% endif %}
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add pamphlet store helpers to read, write, and stat text files with optimistic locking and backups
- implement admin preview, edit, save, and download endpoints and expose a new editing view
- enhance the pamphlet list template with inline preview capabilities and add a dedicated editor page

## Testing
- `pytest` *(fails: missing optional dependencies such as Flask, Pillow, and python-dotenv in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6106ccb1c832c858124ae181a641f