### PR TITLE
fix: dedupe rag sources formatting

### DIFF
--- a/tests/test_pamphlet_fallback.py
+++ b/tests/test_pamphlet_fallback.py
@@ -53,7 +53,8 @@ def test_city_name_query_returns_summary(pamphlet_base):
     assert res.city == "goto"
     assert "要約" in res.message
     assert "詳細" in res.message
-    assert any("history_guide_2025.txt" in src for src in res.sources)
+    assert any("五島市/history_guide_2025" in src for src in res.sources)
+    assert "### 出典" in res.message
     assert res.more_available is False
 
 
@@ -98,7 +99,8 @@ def test_unknown_city_triggers_quick_reply_then_selection(pamphlet_base):
     )
     assert answer.kind == "answer"
     assert answer.city == "goto"
-    assert any("history_guide_2025.txt" in src for src in answer.sources)
+    assert any("五島市/history_guide_2025" in src for src in answer.sources)
+    assert "### 出典" in answer.message
 
     more = pamphlet_flow.build_response(
         "もっと詳しく",

--- a/tests/test_sources_formatting.py
+++ b/tests/test_sources_formatting.py
@@ -1,0 +1,67 @@
+import pytest
+
+from services import pamphlet_rag
+
+
+def test_normalize_sources_from_strings():
+    raw = [
+        "五島市/長崎五島観光ガイド.txt/9-11",
+        "五島市/長崎五島観光ガイド.txt/12-15",
+        "新上五島町/しま山ガイド.md/5-5",
+    ]
+
+    normalized = pamphlet_rag.normalize_sources(raw)
+
+    assert normalized == [
+        ("五島市", "長崎五島観光ガイド"),
+        ("新上五島町", "しま山ガイド"),
+    ]
+
+
+def test_normalize_sources_from_dicts():
+    raw = [
+        {"city": "goto", "file": "五島市_観光ガイドブックひとたび五島.txt", "line_from": 1, "line_to": 5},
+        {"City": "goto", "filename": "五島市_観光ガイドブックひとたび五島.txt", "line_from": 6, "line_to": 8},
+        {"city": "shinkamigoto", "path": "nested/しま山ガイドブック.md", "line_from": 1, "line_to": 2},
+    ]
+
+    normalized = pamphlet_rag.normalize_sources(raw)
+
+    assert normalized == [
+        ("五島市", "五島市_観光ガイドブックひとたび五島"),
+        ("新上五島町", "しま山ガイドブック"),
+    ]
+
+
+def test_normalize_sources_mixed_and_invalid():
+    raw = [
+        "invalid",
+        {"city": None, "file": None},
+        "五島市/長崎五島観光ガイド.txt/9-11",
+        {"city": "goto", "file": "長崎五島観光ガイド.txt"},
+    ]
+
+    normalized = pamphlet_rag.normalize_sources(raw)
+
+    assert normalized == [("五島市", "長崎五島観光ガイド")]
+
+
+def test_format_sources_md_output():
+    raw = [
+        "五島市/長崎五島観光ガイド.txt/9-11",
+        "五島市/長崎五島観光ガイド.txt/12-15",
+        "五島市/五島市_観光ガイドブックひとたび五島.txt/20-21",
+    ]
+
+    md = pamphlet_rag.format_sources_md(raw)
+
+    assert md == (
+        "### 出典\n"
+        "- 五島市/長崎五島観光ガイド\n"
+        "- 五島市/五島市_観光ガイドブックひとたび五島"
+    )
+
+
+def test_format_sources_md_empty():
+    assert pamphlet_rag.format_sources_md([]) == ""
+    assert pamphlet_rag.format_sources_md(None) == ""


### PR DESCRIPTION
## Summary
- add helpers to normalize and format pamphlet RAG sources while removing extensions and line ranges
- update the pamphlet flow to append a deduplicated "出典" footer and expose simplified source labels
- cover the new formatting helpers and flow behaviour with regression tests

## Testing
- pytest tests/test_sources_formatting.py tests/test_pamphlet_fallback.py


------
https://chatgpt.com/codex/tasks/task_e_68d62fcfbb68832c90c1793dea22916f