### PR TITLE
fix: centralize LINE emissions and unify pamphlet sources

### DIFF
--- a/services/pamphlet_flow.py
+++ b/services/pamphlet_flow.py
@@ -15,6 +15,7 @@ class PamphletResponse:
     message: str
     city: Optional[str] = None
     sources: List[str] = field(default_factory=list)
+    sources_md: str = ""
     quick_choices: List[Dict[str, str]] = field(default_factory=list)
     more_available: bool = False
 
@@ -100,12 +101,11 @@ def build_response(
             message=message,
             city=city_key,
             sources=[],
+            sources_md="",
             more_available=False,
         )
 
     footer = pamphlet_rag.format_sources_md(sources_info)
-    if footer:
-        message = f"{message}\n\n{footer}" if message else footer
 
     session.set_followup(user_id, query=stripped, city=city_key)
 
@@ -114,5 +114,6 @@ def build_response(
         message=message,
         city=city_key,
         sources=formatted_sources,
+        sources_md=footer,
         more_available=False,
     )


### PR DESCRIPTION
## Summary
- add a single `emit_response` helper that deduplicates LINE replies, handles push fallbacks once, and enforces the TTL cache
- update the pamphlet flow to surface source metadata separately so the final send composes a single markdown block and routes through the emitter
- route admin utilities and async push helpers through the shared emitter to prevent duplicate deliveries

## Testing
- pytest *(fails: missing optional dependencies such as flask/dotenv/Pillow in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d64109efcc832cac189cfe23500d61