### PR TITLE
feat(admin/pamphlets): add back to data management button

### DIFF
--- a/templates/admin/pamphlets.html
+++ b/templates/admin/pamphlets.html
@@ -56,6 +56,7 @@
 </head>
 <body>
   <div class="container">
+    {% include '_back_to_data.html' %}
     {% include '_admin_nav.html' %}
     <h1>パンフレットテキスト管理</h1>
 

--- a/templates/admin/pamphlets_edit.html
+++ b/templates/admin/pamphlets_edit.html
@@ -38,6 +38,7 @@
 </head>
 <body>
   <div class="container">
+    {% include '_back_to_data.html' %}
     {% include '_admin_nav.html' %}
     <h1>{{ cities[city] }} / {{ name }}</h1>
 


### PR DESCRIPTION
## Summary
- include the shared back-to-data button partial on the pamphlet list view
- include the same button on the pamphlet edit view so both screens match other admin pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d659cb8814832cbc4db03208078ca4