### PR TITLE
Add anti-flood guards and LINE push idempotency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !README.md
 !requirements.txt
 !app.py
+!antiflood.py
 !conversational_router.py
 !notices.json
 !shop_infos.json

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## 概要
 
-五島列島の観光・生活情報をAIがLINEやWebで自動回答する、地域特化型のFAQ・サポートシステムです。  
-登録された観光データやパンフレット情報、タグ・エリア指定で高精度な回答ができます。  
+五島列島の観光・生活情報をAIがLINEやWebで自動回答する、地域特化型のFAQ・サポートシステムです。
+登録された観光データやパンフレット情報、タグ・エリア指定で高精度な回答ができます。
 管理画面からデータ登録・誤答補強・バックアップ・未ヒット抽出・類義語管理までノーコード運用可能！
 
 ---
@@ -25,3 +25,42 @@
 
 ```bash
 pip install -r requirements.txt
+```
+
+### 2. 主な環境変数（.env）
+
+| 環境変数 | 既定値 | 説明 |
+| --- | --- | --- |
+| `LINE_CHANNEL_ACCESS_TOKEN` / `LINE_CHANNEL_SECRET` | なし | LINE公式アカウントのチャネル情報。必須。 |
+| `DATA_BASE_DIR` | `.` | `entries.json` や AntiFlood SQLite を配置するルートディレクトリ。Render では `/var/data` 等を指定。 |
+| `ANTIFLOOD_TTL_SEC` | `180` | 「ユーザーID + メッセージID + 正規化テキスト」をキーにしたAntiFloodのTTL。再送イベントはTTL内なら自動で無視されます。 |
+| `REPLAY_GUARD_SEC` | `150` | この秒数より古いイベントを再生ガードとして破棄。遅延再送・リトライの暴走を防ぎます。 |
+| `RECENT_TEXT_TTL_SEC` | `min(ANTIFLOOD_TTL_SEC, 60)` | 同一本文の短時間連投を抑止するTTL。 |
+| `ENABLE_PUSH` | `true` | `false` の場合は push 送信を完全停止し、reply のみで運用します。 |
+| `ANTIFLOOD_REDIS_URL` / `REDIS_URL` | なし | Redis を使う場合は指定すると AntiFlood が Redis バックエンドを利用します。未設定時は `DATA_BASE_DIR/system/antiflood.sqlite` が使われます。 |
+
+> **メモ:** SQLite バックエンドは `DATA_BASE_DIR` 配下に `system/antiflood.sqlite` を自動生成します。Render では永続ボリューム上にこのディレクトリを置くことで、再起動後も冪等キーが保持されます。
+
+### 3. テスト実行
+
+AntiFlood や webhook の冪等性を検証する Pytest を同梱しています。デプロイ前に必ず実行してください。
+
+```bash
+pytest
+```
+
+### 4. Render へのデプロイ手順
+
+1. Render ダッシュボードで `DATA_BASE_DIR=/var/data` など永続ボリューム上のディレクトリを設定します。
+2. `ANTIFLOOD_TTL_SEC`・`REPLAY_GUARD_SEC`・`ENABLE_PUSH` を本番と同じ値で登録し、Redis を使う場合は `ANTIFLOOD_REDIS_URL` も追加します。
+3. Web サービスは 1 ワーカー運用が推奨です。APScheduler などを追加する場合も `scheduler.start()` は 1 度だけ呼び出す構成にしてください。
+4. デプロイ後に Render のログで `/callback` が即時 200 を返していること、重複 push が出ていないことを確認します。
+5. ステージング / 本番それぞれで LINE の開発者ツールを使い、同一メッセージ再送や遅延再送が無視されることを実機で確認します。
+
+### 5. ロールバック方法
+
+環境変数のみで制御できるため、緊急時は以下の手順で旧挙動に戻せます。
+
+1. `ENABLE_PUSH=false` にすると push 送信が全停止し、reply のみになります。
+2. `ANTIFLOOD_TTL_SEC=0` と `REPLAY_GUARD_SEC=0` を設定すると AntiFlood / 再生ガードが無効化されます（再試行時は重複応答が発生する点に注意）。
+3. 変更後に Render を再デプロイすると即座に反映されます。

--- a/antiflood.py
+++ b/antiflood.py
@@ -1,0 +1,218 @@
+import logging
+import os
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from hashlib import sha1
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+try:  # Optional redis dependency
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - redis is optional
+    redis = None
+
+logger = logging.getLogger(__name__)
+
+
+def _sha1(data: str) -> str:
+    return sha1(data.encode("utf-8")).hexdigest()
+
+
+def normalize_text(text: str | None) -> str:
+    if text is None:
+        return ""
+    try:
+        import unicodedata
+
+        normalized = unicodedata.normalize("NFKC", str(text))
+    except Exception:  # pragma: no cover - extremely rare
+        normalized = str(text)
+    normalized = normalized.strip()
+    if not normalized:
+        return ""
+    return " ".join(normalized.split()).lower()
+
+
+def make_key(*parts: Iterable[str | int | float | None]) -> str:
+    flat: list[str] = []
+    for part in parts:
+        if part is None:
+            continue
+        if isinstance(part, (list, tuple)):
+            flat.append(make_key(*part))
+            continue
+        flat.append(str(part))
+    if not flat:
+        return ""
+    return _sha1("||".join(flat))
+
+
+def make_event_key(user_id: str | None, message_id: str | None, normalized_text: str | None) -> str:
+    return make_key("event", user_id or "", message_id or "", normalized_text or "")
+
+
+def make_text_key(user_id: str | None, normalized_text: str | None) -> str:
+    return make_key("text", user_id or "", normalized_text or "")
+
+
+def make_push_key(user_id: str | None, payload: str | None) -> str:
+    return make_key("push", user_id or "", payload or "")
+
+
+class _SqliteBackend:
+    def __init__(self, path: Path, namespace: str, time_func: Callable[[], float]):
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._namespace = namespace
+        self._time_func = time_func
+        self._init_db()
+
+    def _get_conn(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._path))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        return conn
+
+    def _init_db(self) -> None:
+        with self._get_conn() as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS antiflood (key TEXT PRIMARY KEY, expire_at INTEGER NOT NULL)"
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_expire ON antiflood(expire_at)")
+            conn.commit()
+
+    def acquire(self, key: str, ttl: int, now: int) -> bool:
+        if not key:
+            return True
+        expire_at = now + ttl
+        with self._lock:
+            with self._get_conn() as conn:
+                conn.execute("DELETE FROM antiflood WHERE expire_at <= ?", (now,))
+                try:
+                    conn.execute(
+                        "INSERT INTO antiflood(key, expire_at) VALUES (?, ?)", (key, expire_at)
+                    )
+                    conn.commit()
+                    return True
+                except sqlite3.IntegrityError:
+                    return False
+
+    def contains(self, key: str, now: int) -> bool:
+        if not key:
+            return False
+        with self._lock:
+            with self._get_conn() as conn:
+                conn.execute("DELETE FROM antiflood WHERE expire_at <= ?", (now,))
+                cur = conn.execute("SELECT 1 FROM antiflood WHERE key = ? LIMIT 1", (key,))
+                return cur.fetchone() is not None
+
+    def clear(self) -> None:
+        with self._lock:
+            with self._get_conn() as conn:
+                conn.execute("DELETE FROM antiflood")
+                conn.commit()
+
+
+class _RedisBackend:
+    def __init__(self, url: str, namespace: str):
+        if not redis:
+            raise RuntimeError("redis package is not available")
+        self._client = redis.Redis.from_url(url)
+        self._prefix = f"{namespace}:"
+
+    def _key(self, key: str) -> str:
+        return key
+
+    def acquire(self, key: str, ttl: int, now: int) -> bool:  # noqa: D401 - same API
+        if not key:
+            return True
+        return bool(self._client.set(name=key, value="1", ex=ttl, nx=True))
+
+    def contains(self, key: str, now: int) -> bool:
+        if not key:
+            return False
+        return bool(self._client.exists(key))
+
+    def clear(self) -> None:
+        pattern = f"{self._prefix}*"
+        for name in self._client.scan_iter(match=pattern):
+            self._client.delete(name)
+
+
+@dataclass
+class AntiFlood:
+    backend: object
+    namespace: str
+    time_func: Callable[[], float]
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        base_dir: str | os.PathLike[str] | None = None,
+        redis_url: str | None = None,
+        namespace: str = "antiflood",
+        time_func: Optional[Callable[[], float]] = None,
+    ) -> "AntiFlood":
+        base_dir = Path(base_dir or os.environ.get("DATA_BASE_DIR", "."))
+        redis_url = redis_url or os.environ.get("ANTIFLOOD_REDIS_URL") or os.environ.get("REDIS_URL")
+        if time_func is None:
+            time_func = time.time
+
+        if redis_url:
+            try:
+                backend = _RedisBackend(redis_url, namespace)
+                logger.info("AntiFlood using Redis backend: %s", redis_url)
+                return cls(backend=backend, namespace=namespace, time_func=time_func)
+            except Exception as exc:  # pragma: no cover - depends on runtime redis availability
+                logger.warning("Redis backend unavailable (%s), falling back to sqlite", exc)
+
+        sqlite_path = base_dir / "system" / "antiflood.sqlite"
+        backend = _SqliteBackend(sqlite_path, namespace, time_func)
+        logger.info("AntiFlood using sqlite backend at %s", sqlite_path)
+        return cls(backend=backend, namespace=namespace, time_func=time_func)
+
+    def _ns(self, key: str) -> str:
+        return f"{self.namespace}:{key}" if key else key
+
+    def acquire(self, key: str, ttl_sec: int) -> bool:
+        if not key:
+            return True
+        ttl = int(ttl_sec)
+        if ttl <= 0:
+            return True
+        try:
+            now = int(self.time_func())
+            return bool(getattr(self.backend, "acquire")(self._ns(key), ttl, now))
+        except Exception as exc:
+            logger.warning("AntiFlood.acquire failed for %s: %s", key, exc)
+            return True
+
+    def contains(self, key: str) -> bool:
+        if not key:
+            return False
+        try:
+            now = int(self.time_func())
+            return bool(getattr(self.backend, "contains")(self._ns(key), now))
+        except Exception as exc:
+            logger.warning("AntiFlood.contains failed for %s: %s", key, exc)
+            return False
+
+    def clear(self) -> None:
+        try:
+            getattr(self.backend, "clear")()
+        except Exception as exc:
+            logger.warning("AntiFlood.clear failed: %s", exc)
+
+
+__all__ = [
+    "AntiFlood",
+    "make_event_key",
+    "make_key",
+    "make_push_key",
+    "make_text_key",
+    "normalize_text",
+]

--- a/tests/test_antiflood.py
+++ b/tests/test_antiflood.py
@@ -1,0 +1,24 @@
+import time
+
+from antiflood import AntiFlood, make_event_key, make_text_key, normalize_text
+
+
+def test_antiflood_acquire_and_contains(tmp_path):
+    current = [time.time()]
+
+    antiflood = AntiFlood.from_env(base_dir=tmp_path, time_func=lambda: current[0])
+    antiflood.clear()
+
+    key = make_event_key("user", "msg", "hello")
+    assert antiflood.acquire(key, 5) is True
+    assert antiflood.contains(key) is True
+    assert antiflood.acquire(key, 5) is False
+
+    current[0] += 6
+    assert antiflood.contains(key) is False
+    assert antiflood.acquire(key, 5) is True
+
+    text_key = make_text_key("user", normalize_text("テスト"))
+    assert antiflood.acquire(text_key, 1) is True
+    current[0] += 2
+    assert antiflood.contains(text_key) is False

--- a/tests/test_webhook_idempotency.py
+++ b/tests/test_webhook_idempotency.py
@@ -1,0 +1,139 @@
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+
+import app
+from antiflood import AntiFlood
+
+
+class DummyLineApi:
+    def __init__(self):
+        self.reply_calls = []
+        self.push_calls = []
+
+    def reply_message(self, token, messages, *args, **kwargs):
+        self.reply_calls.append((token, messages))
+
+    def push_message(self, to, messages, *args, **kwargs):
+        self.push_calls.append((to, messages))
+
+    def get_profile(self, user_id):
+        class _Profile:
+            display_name = "tester"
+
+        return _Profile()
+
+
+def _signature(body: str) -> str:
+    secret = (app.LINE_CHANNEL_SECRET or "dummy").encode("utf-8")
+    return base64.b64encode(
+        hmac.new(secret, body.encode("utf-8"), hashlib.sha256).digest()
+    ).decode("utf-8")
+
+
+def _post_message(client, body_dict):
+    body = json.dumps(body_dict, separators=(",", ":"))
+    sig = _signature(body)
+    return client.post(
+        "/callback",
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Line-Signature": sig,
+        },
+    )
+
+
+@pytest.fixture
+def patched_env(monkeypatch, tmp_path):
+    current = [time.time()]
+    antiflood = AntiFlood.from_env(base_dir=tmp_path, time_func=lambda: current[0])
+    antiflood.clear()
+
+    dummy_api = DummyLineApi()
+    monkeypatch.setattr(app, "line_bot_api", dummy_api, raising=False)
+    monkeypatch.setattr(app, "ANTIFLOOD", antiflood, raising=False)
+    monkeypatch.setattr(app, "ANTIFLOOD_TTL_SEC", 120, raising=False)
+    monkeypatch.setattr(app, "RECENT_TEXT_TTL_SEC", 60, raising=False)
+    monkeypatch.setattr(app, "REPLAY_GUARD_SEC", 150, raising=False)
+    monkeypatch.setattr(app, "ENABLE_PUSH", True, raising=False)
+    monkeypatch.setattr(app, "_line_enabled", lambda: True)
+    monkeypatch.setattr(app, "_line_mute_gate", lambda *args, **kwargs: False)
+    monkeypatch.setattr(app, "get_weather_reply", lambda text: ("", False))
+    monkeypatch.setattr(app, "get_mobility_reply", lambda text: ("", False))
+    monkeypatch.setattr(app, "get_transport_reply", lambda text: ("", False))
+    monkeypatch.setattr(app, "smalltalk_or_help_reply", lambda text: "テスト応答")
+    monkeypatch.setattr(app, "save_qa_log", lambda *args, **kwargs: None)
+
+    return antiflood, current, dummy_api
+
+
+def test_webhook_deduplicates_events(patched_env):
+    antiflood, current, dummy_api = patched_env
+    client = app.app.test_client()
+
+    def make_body(message_id: str, text: str, ts_ms: int):
+        return {
+            "destination": "dummy",
+            "events": [
+                {
+                    "type": "message",
+                    "timestamp": ts_ms,
+                    "replyToken": "token",
+                    "source": {"type": "user", "userId": "U1"},
+                    "message": {"id": message_id, "type": "text", "text": text},
+                }
+            ],
+        }
+
+    now_sec = current[0]
+    now_ts = int(now_sec * 1000)
+
+    res = _post_message(client, make_body("msg-1", "テストです", now_ts))
+    assert res.status_code == 200
+    assert len(dummy_api.reply_calls) == 1
+
+    res = _post_message(client, make_body("msg-1", "テストです", now_ts))
+    assert res.status_code == 200
+    assert len(dummy_api.reply_calls) == 1
+
+    res = _post_message(client, make_body("msg-2", "テストです", now_ts + 1000))
+    assert res.status_code == 200
+    assert len(dummy_api.reply_calls) == 1
+
+    current[0] += 200
+    future_ts = int(current[0] * 1000)
+    res = _post_message(client, make_body("msg-3", "テストです", future_ts))
+    assert res.status_code == 200
+    assert len(dummy_api.reply_calls) == 2
+
+    old_ts = int((time.time() - app.REPLAY_GUARD_SEC - 10) * 1000)
+    res = _post_message(client, make_body("msg-4", "別のメッセージ", old_ts))
+    assert res.status_code == 200
+    assert len(dummy_api.reply_calls) == 2
+
+
+def test_safe_push_line_deduplicates(monkeypatch, tmp_path):
+    current = [time.time()]
+    antiflood = AntiFlood.from_env(base_dir=tmp_path, time_func=lambda: current[0])
+    antiflood.clear()
+
+    dummy_api = DummyLineApi()
+    monkeypatch.setattr(app, "line_bot_api", dummy_api, raising=False)
+    monkeypatch.setattr(app, "ANTIFLOOD", antiflood, raising=False)
+    monkeypatch.setattr(app, "ANTIFLOOD_TTL_SEC", 180, raising=False)
+    monkeypatch.setattr(app, "ENABLE_PUSH", True, raising=False)
+    monkeypatch.setattr(app, "_line_enabled", lambda: True)
+
+    assert app.safe_push_line("U1", ["push test"], label="unit") is True
+    assert len(dummy_api.push_calls) == 1
+    assert app.safe_push_line("U1", ["push test"], label="unit") is False
+    assert len(dummy_api.push_calls) == 1
+
+    current[0] += 200
+    assert app.safe_push_line("U1", ["push test"], label="unit") is True
+    assert len(dummy_api.push_calls) == 2

--- a/watermark_ext.py
+++ b/watermark_ext.py
@@ -812,10 +812,15 @@ def view_admin_media_delete():
     _ensure_role()
 
     # 入力取得
-    raw = request.form.get("filename") or ""
-    name = _normalize_selection(raw)
+    raw = (request.form.get("filename") or "").strip()
 
     # --- ここで厳格に弾く（400を返す） ---
+    raw_parts = PurePosixPath(raw).parts
+    if raw.startswith(("/", "\\")) or any(part == ".." for part in raw_parts):
+        abort(400)
+
+    name = _normalize_selection(raw)
+
     # 空・絶対パス・.. を含む相対移動はいずれも拒否
     if (not name) or name.startswith(("/", "\\")) or (".." in PurePosixPath(name).parts):
         abort(400)


### PR DESCRIPTION
## Summary
- add a reusable antiflood storage module with sqlite/redis backends and wire it into LINE webhook handlers, replay guards, and safe push delivery【F:antiflood.py†L1-L170】【F:app.py†L116-L412】
- harden LINE message handling to drop stale/duplicate events and send push replies through a new safe_push_line helper, while tightening admin media deletion validation【F:app.py†L3159-L3705】【F:watermark_ext.py†L808-L845】
- document required environment flags and ship regression tests that cover antiflood behavior and webhook/push idempotency【F:README.md†L1-L67】【F:tests/test_webhook_idempotency.py†L1-L144】【F:tests/test_antiflood.py†L1-L24】

## Testing
- pytest【2d5fab†L1-L9】

------
https://chatgpt.com/codex/tasks/task_e_68d68fec1398832ca05a882d2997e262