### PR TITLE
Adopt polite long-form pamphlet summaries

### DIFF
--- a/services/summary_config.py
+++ b/services/summary_config.py
@@ -1,0 +1,73 @@
+"""Helpers for shared summary generation configuration."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+_DEFAULT_STYLE = "polite_long"
+_DEFAULT_MIN = 550
+_DEFAULT_MAX = 800
+_DEFAULT_FALLBACK = 300
+
+
+@dataclass(frozen=True)
+class SummaryBounds:
+    min_chars: int
+    max_chars: int
+    is_short_context: bool
+
+
+def get_summary_style() -> str:
+    """Return the configured summary style."""
+    value = os.getenv("SUMMARY_STYLE", _DEFAULT_STYLE)
+    value = (value or "").strip().lower()
+    return value or _DEFAULT_STYLE
+
+
+def _read_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw.strip())
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def get_summary_min_chars() -> int:
+    return _read_int("SUMMARY_MIN_CHARS", _DEFAULT_MIN)
+
+
+def get_summary_max_chars() -> int:
+    return _read_int("SUMMARY_MAX_CHARS", _DEFAULT_MAX)
+
+
+def get_summary_min_fallback() -> int:
+    return _read_int("SUMMARY_MIN_FALLBACK", _DEFAULT_FALLBACK)
+
+
+def get_summary_bounds(context_text: str | None) -> SummaryBounds:
+    """Determine length targets based on context richness."""
+    min_chars = get_summary_min_chars()
+    max_chars = get_summary_max_chars()
+    fallback = get_summary_min_fallback()
+
+    text = (context_text or "").strip()
+    context_len = len(text)
+    line_count = text.count("\n") + 1 if text else 0
+
+    short_threshold = max(400, fallback * 2)
+    is_short = context_len <= short_threshold or line_count <= 2
+
+    if is_short:
+        short_min = fallback
+        short_max = min(max_chars, max(fallback + 200, 500))
+        if short_max < short_min:
+            short_max = short_min
+        return SummaryBounds(min_chars=short_min, max_chars=short_max, is_short_context=True)
+
+    if max_chars < min_chars:
+        max_chars = min_chars
+
+    return SummaryBounds(min_chars=min_chars, max_chars=max_chars, is_short_context=False)

--- a/tests/smoke/rag_demo.py
+++ b/tests/smoke/rag_demo.py
@@ -22,11 +22,8 @@ def run_demo() -> dict:
         vector_index=None,
     )
     context, id_map = pamphlet_rag.build_context_with_labels([candidate])
-    prompt = pamphlet_rag._build_prompt("観光スポットは？", "goto", ["観光"], context)
-    mocked_answer = (
-        "### 要約\n五島市のパンフレットでは主要な観光地が紹介されています。[[1]]\n\n"
-        "### 出典\n- 五島市/demo[[1]]"
-    )
+    prompt_cfg = pamphlet_rag._build_prompt("観光スポットは？", "goto", ["観光"], context)
+    mocked_answer = "五島市のパンフレットでは主要な観光地が紹介されています。[[1]]"
     result = pamphlet_rag.postprocess_answer(
         mocked_answer,
         id_map,
@@ -34,7 +31,7 @@ def run_demo() -> dict:
         min_score=0.0,
     )
     return {
-        "prompt": prompt,
+        "prompt": prompt_cfg.prompt,
         "context": context,
         "answer_without_labels": result.answer_without_labels,
         "answer_with_labels": result.answer_with_labels,

--- a/tests/test_pamphlet_fallback.py
+++ b/tests/test_pamphlet_fallback.py
@@ -51,7 +51,7 @@ def test_city_name_query_returns_summary(pamphlet_base):
 
     assert res.kind == "answer"
     assert res.city == "goto"
-    assert "要約" in res.message
+    assert "資料" in res.message
     assert any("五島市/history_guide_2025" in src for src in res.sources)
     assert res.sources_md.startswith("### 出典")
     assert res.more_available is False


### PR DESCRIPTION
## Summary
- add a shared summary configuration helper and switch the RAG prompt to the new polite-long instructions with length control
- update the pamphlet message builder to render paragraph-style summaries while keeping the terse format available via an env toggle
- refresh regression tests for the new style and add coverage for truncation behaviour

## Testing
- pytest tests/test_message_builder.py tests/test_citation_pipeline.py tests/test_pamphlet_fallback.py tests/smoke/rag_demo.py


------
https://chatgpt.com/codex/tasks/task_e_68d72f401bb8832ca21ed07347a0f0ef