### PR TITLE
Ensure routing priority and tighten pamphlet safeguards

### DIFF
--- a/services/route_selector.py
+++ b/services/route_selector.py
@@ -1,0 +1,70 @@
+"""Routing helpers for prioritising conversation handlers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Tuple
+
+
+Probe = Callable[[str], Any]
+
+
+@dataclass
+class RouteDecision:
+    """Result returned by :func:`select_route`."""
+
+    route: str
+    payload: Any = None
+
+
+def _interpret_probe_result(result: Any) -> Tuple[bool, Any]:
+    """Normalise probe outputs.
+
+    A probe may return a boolean, a payload, or ``(handled, payload)``.
+    """
+
+    if isinstance(result, tuple) and result:
+        head = result[0]
+        handled = bool(head)
+        payload = result[1] if len(result) > 1 else None
+        return handled, payload
+
+    if isinstance(result, bool):
+        return result, None
+
+    handled = bool(result)
+    return handled, result if handled else None
+
+
+def select_route(
+    text: str,
+    *,
+    special_probe: Optional[Probe] = None,
+    tourism_probe: Optional[Probe] = None,
+    pamphlet_probe: Optional[Probe] = None,
+) -> RouteDecision:
+    """Choose the handler route following the mandated priority.
+
+    Priority: ``special`` → ``tourism`` → ``pamphlet`` → ``no_answer``.
+    Each probe is invoked at most once; subsequent probes are skipped once
+    a handler claims the message.  This keeps side effects (DB lookups,
+    logging) deterministic and avoids accidental fallback execution.
+    """
+
+    ordered: Tuple[Tuple[str, Optional[Probe]], ...] = (
+        ("special", special_probe),
+        ("tourism", tourism_probe),
+        ("pamphlet", pamphlet_probe),
+    )
+
+    for route, probe in ordered:
+        if probe is None:
+            continue
+        handled, payload = _interpret_probe_result(probe(text))
+        if handled:
+            return RouteDecision(route=route, payload=payload)
+
+    return RouteDecision(route="no_answer", payload=None)
+
+
+__all__ = ["RouteDecision", "select_route"]

--- a/tests/test_citations_guard.py
+++ b/tests/test_citations_guard.py
@@ -1,0 +1,111 @@
+import re
+
+import pytest
+
+from services import pamphlet_flow, pamphlet_search
+
+
+@pytest.fixture
+def pamphlet_env(tmp_path, monkeypatch):
+    base = tmp_path / "pamphlets"
+    (base / "goto").mkdir(parents=True, exist_ok=True)
+    (base / "goto" / "history.txt").write_text(
+        "五島市の歴史や教会群について紹介する資料です。\n"
+        "主要な観光スポットやアクセス、文化行事が詳しくまとめられています。\n",
+        encoding="utf-8",
+    )
+    (base / "goto" / "food.txt").write_text(
+        "五島うどんや海鮮料理、島内の飲食店情報を掲載した資料です。",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("SUMMARY_STYLE", "polite_long")
+    pamphlet_search.configure(
+        {
+            "PAMPHLET_BASE_DIR": str(base),
+            "PAMPHLET_CHUNK_SIZE": 300,
+            "PAMPHLET_CHUNK_OVERLAP": 20,
+        }
+    )
+    pamphlet_search.reindex_all()
+    return base
+
+
+def _labels_in_message(text: str) -> set[int]:
+    pattern = re.compile(r"\[\[(\d+)\]\]")
+    return {int(m.group(1)) for m in pattern.finditer(text)}
+
+
+def _sentences(text: str) -> list[str]:
+    header_split = text.split("### 出典", 1)[0]
+    parts = [seg for seg in re.split(r"(?<=[。！？!?])", header_split) if seg]
+    sentences: list[str] = []
+    buffer = ""
+    for part in parts:
+        chunk = part.strip()
+        if not chunk:
+            continue
+        buffer = f"{buffer}{chunk}" if buffer else chunk
+        if buffer.endswith("]]"):
+            sentences.append(buffer)
+            buffer = ""
+    if buffer:
+        sentences.append(buffer)
+    return sentences
+
+
+def test_each_sentence_has_label(pamphlet_env):
+    session = {}
+    res = pamphlet_flow.build_response(
+        "五島市の歴史を詳しく教えて",
+        user_id="u1",
+        session_store=session,
+        topk=2,
+        ttl=600,
+        searcher=lambda city, query, limit: pamphlet_search.search(city, query, limit),
+        summarizer=lambda *args, **kwargs: "",
+    )
+
+    assert res.kind == "answer"
+    sentences = _sentences(res.message)
+    assert sentences, "summary should contain sentences"
+    for sentence in sentences:
+        assert sentence.endswith("]]")
+
+
+def test_sources_match_used_labels(pamphlet_env):
+    session = {}
+    res = pamphlet_flow.build_response(
+        "五島市のおすすめグルメ", user_id="u2", session_store=session, topk=2, ttl=600,
+        searcher=lambda city, query, limit: pamphlet_search.search(city, query, limit),
+        summarizer=lambda *args, **kwargs: "",
+    )
+
+    assert res.kind == "answer"
+    labels = _labels_in_message(res.message)
+    allowed_labels = {label for citation in res.citations for label in citation.get("labels", [])}
+    assert labels.issubset(allowed_labels)
+    expected_sources = {
+        f"{citation.get('city')}/{citation.get('file') or citation.get('title')}"
+        for citation in res.citations
+    }
+    assert set(res.sources) == expected_sources
+
+
+def test_no_external_labels_when_not_available(pamphlet_env):
+    session = {}
+    res = pamphlet_flow.build_response(
+        "五島市で宇宙旅行の方法を教えて",
+        user_id="u3",
+        session_store=session,
+        topk=2,
+        ttl=600,
+        searcher=lambda city, query, limit: pamphlet_search.search(city, query, limit),
+        summarizer=lambda *args, **kwargs: "",
+    )
+
+    assert res.kind in {"error", "answer"}
+    if res.kind == "answer":
+        labels = _labels_in_message(res.message)
+        allowed_labels = {ref_label for citation in res.citations for ref_label in citation.get("labels", [])}
+        assert labels.issubset(allowed_labels)

--- a/tests/test_controls_antiflood.py
+++ b/tests/test_controls_antiflood.py
@@ -1,0 +1,133 @@
+import importlib
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+
+class DummyEvent:
+    def __init__(self, user_id: str = "U123") -> None:
+        self.reply_token = "dummy"
+        self.source = SimpleNamespace(user_id=user_id, group_id=None, room_id=None)
+
+
+@pytest.fixture
+def control_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("USER_STATE_DB_PATH", str(tmp_path / "user_state.sqlite"))
+    monkeypatch.setenv("CONTROL_CMD_ENABLED", "true")
+    monkeypatch.setenv("PAUSE_DEFAULT_TTL_SEC", "120")
+    monkeypatch.setenv("ANTIFLOOD_TTL_SEC", "180")
+    monkeypatch.setenv("REPLAY_GUARD_SEC", "150")
+
+    state = importlib.import_module("services.state")
+    dupe = importlib.import_module("services.dupe_guard")
+    handlers = importlib.import_module("services.line_handlers")
+
+    state = importlib.reload(state)
+    dupe = importlib.reload(dupe)
+    handlers = importlib.reload(handlers)
+
+    state.reset_for_tests()
+    dupe.reset()
+
+    yield state, dupe, handlers
+
+    dupe.reset()
+    state.reset_for_tests()
+
+
+def test_resume_allows_followup(control_env):
+    state, dupe, handlers = control_env
+    event = DummyEvent()
+    logger = logging.getLogger("test.controls")
+
+    allowed_initial = dupe.should_process_incoming(
+        user_id=event.source.user_id,
+        message_id="m1",
+        text="こんにちは",
+        event_ts=100.0,
+        now=100.0,
+    )
+    assert allowed_initial is True
+
+    handlers.process_control_command(
+        "停止 2分",
+        user_id=event.source.user_id,
+        event=event,
+        reply_func=lambda *_: None,
+        logger=logger,
+        now=100,
+    )
+    assert state.is_paused(event.source.user_id, 101)
+
+    handlers.process_control_command(
+        "解除",
+        user_id=event.source.user_id,
+        event=event,
+        reply_func=lambda *_: None,
+        logger=logger,
+        now=102,
+    )
+
+    allowed_after = dupe.should_process_incoming(
+        user_id=event.source.user_id,
+        message_id="m2",
+        text="観光情報",
+        event_ts=103.0,
+        now=103.0,
+    )
+    assert allowed_after is True
+
+
+def test_duplicate_message_suppressed(control_env):
+    _state, dupe, _handlers = control_env
+
+    assert dupe.should_process_incoming(
+        user_id="U", message_id="mid", text="質問", event_ts=200.0, now=200.0
+    ) is True
+    assert dupe.should_process_incoming(
+        user_id="U", message_id="mid", text="質問", event_ts=201.0, now=201.0
+    ) is False
+
+    # 同じ本文が短時間で再送された場合も抑止される
+    assert dupe.should_process_incoming(
+        user_id="U", message_id="other", text="質問", event_ts=202.0, now=202.0
+    ) is False
+
+
+def test_old_events_rejected(control_env):
+    _state, dupe, _handlers = control_env
+
+    now = 500.0
+    assert dupe.should_process_incoming(
+        user_id="U", message_id="fresh", text="最新", event_ts=now, now=now
+    ) is True
+    assert dupe.should_process_incoming(
+        user_id="U", message_id="old", text="遅延", event_ts=now - 200, now=now
+    ) is False
+
+
+def test_resume_command_not_blocked(control_env):
+    _state, _dupe, handlers = control_env
+    event = DummyEvent("U-resume")
+    logger = logging.getLogger("test.controls")
+
+    first = handlers.process_control_command(
+        "解除",
+        user_id=event.source.user_id,
+        event=event,
+        reply_func=lambda *_: None,
+        logger=logger,
+        now=10,
+    )
+    second = handlers.process_control_command(
+        "解除",
+        user_id=event.source.user_id,
+        event=event,
+        reply_func=lambda *_: None,
+        logger=logger,
+        now=11,
+    )
+
+    assert first["action"] == "resume"
+    assert second["action"] == "resume"

--- a/tests/test_routing_priority.py
+++ b/tests/test_routing_priority.py
@@ -1,0 +1,94 @@
+from services.route_selector import RouteDecision, select_route
+
+
+class Probe:
+    def __init__(self, *responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def __call__(self, text: str):
+        self.calls.append(text)
+        if not self._responses:
+            return False
+        return self._responses.pop(0)
+
+
+def test_special_route_has_highest_priority():
+    special = Probe((True, "weather"))
+    tourism = Probe(True)
+    pamphlet = Probe(True)
+
+    decision = select_route(
+        "今日の天気は？",
+        special_probe=special,
+        tourism_probe=tourism,
+        pamphlet_probe=pamphlet,
+    )
+
+    assert isinstance(decision, RouteDecision)
+    assert decision.route == "special"
+    assert tourism.calls == []
+    assert pamphlet.calls == []
+
+
+def test_multiple_special_intents_share_priority():
+    special = Probe((True, "運行状況"))
+    tourism = Probe()
+    pamphlet = Probe()
+
+    decision = select_route(
+        "運行状況を教えて",
+        special_probe=special,
+        tourism_probe=tourism,
+        pamphlet_probe=pamphlet,
+    )
+
+    assert decision.route == "special"
+    assert tourism.calls == []
+    assert pamphlet.calls == []
+
+    special = Probe((True, "展望所マップ"))
+    decision = select_route(
+        "展望所マップ",
+        special_probe=special,
+        tourism_probe=tourism,
+        pamphlet_probe=pamphlet,
+    )
+    assert decision.route == "special"
+
+
+def test_tourism_when_special_fails():
+    special = Probe(False)
+    tourism_payload = {"title": "観光スポット"}
+    tourism = Probe((True, tourism_payload))
+    pamphlet = Probe()
+
+    decision = select_route(
+        "福江島の観光地", special_probe=special, tourism_probe=tourism, pamphlet_probe=pamphlet
+    )
+
+    assert decision.route == "tourism"
+    assert decision.payload == tourism_payload
+    assert pamphlet.calls == []
+
+
+def test_pamphlet_when_tourism_missing():
+    special = Probe(False)
+    tourism = Probe(False)
+    pamphlet = Probe((True, {"city": "goto"}))
+
+    decision = select_route(
+        "五島市の歴史", special_probe=special, tourism_probe=tourism, pamphlet_probe=pamphlet
+    )
+
+    assert decision.route == "pamphlet"
+    assert decision.payload == {"city": "goto"}
+
+
+def test_no_answer_when_all_handlers_decline():
+    decision = select_route(
+        "未知の質問です", special_probe=lambda _: False, tourism_probe=lambda _: False, pamphlet_probe=lambda _: False
+    )
+
+    assert decision.route == "no_answer"
+    assert decision.payload is None

--- a/tests/test_summary_length.py
+++ b/tests/test_summary_length.py
@@ -1,0 +1,97 @@
+import re
+
+import pytest
+
+from services import pamphlet_flow, pamphlet_rag, pamphlet_search
+
+
+@pytest.fixture
+def summary_env(tmp_path, monkeypatch):
+    base = tmp_path / "pamphlets"
+    (base / "goto").mkdir(parents=True, exist_ok=True)
+    long_text = "五島市の自然や文化、観光スポットを詳しく紹介する資料です。" * 60
+    (base / "goto" / "guide.txt").write_text(long_text, encoding="utf-8")
+    short_text = "行事予定とお問い合わせ先を簡潔にまとめた資料です。"
+    (base / "goto" / "short.txt").write_text(short_text, encoding="utf-8")
+
+    monkeypatch.setenv("SUMMARY_STYLE", "polite_long")
+    monkeypatch.setenv("SUMMARY_MIN_CHARS", "550")
+    monkeypatch.setenv("SUMMARY_MAX_CHARS", "800")
+    monkeypatch.setenv("SUMMARY_MIN_FALLBACK", "300")
+
+    pamphlet_search.configure(
+        {
+            "PAMPHLET_BASE_DIR": str(base),
+            "PAMPHLET_CHUNK_SIZE": 400,
+            "PAMPHLET_CHUNK_OVERLAP": 40,
+        }
+    )
+    pamphlet_search.reindex_all()
+    return base
+
+
+def _summary_text(message: str) -> str:
+    return message.split("### 出典", 1)[0].strip()
+
+
+def _length(text: str) -> int:
+    return len(re.sub(r"\s+", "", text))
+
+
+def test_standard_summary_respects_bounds(summary_env):
+    session = {}
+    res = pamphlet_flow.build_response(
+        "五島市の観光情報を詳しく教えて",
+        user_id="s1",
+        session_store=session,
+        topk=2,
+        ttl=600,
+        searcher=lambda city, query, limit: pamphlet_search.search(city, query, limit),
+        summarizer=lambda *args, **kwargs: "",
+    )
+
+    assert res.kind == "answer"
+    summary = _summary_text(res.message)
+    length = _length(summary)
+    assert 550 <= length <= 800
+
+
+def test_short_context_uses_fallback_min(summary_env):
+    session = {}
+    res = pamphlet_flow.build_response(
+        "五島市の行事予定について",
+        user_id="s2",
+        session_store=session,
+        topk=1,
+        ttl=600,
+        searcher=lambda city, query, limit: pamphlet_search.search(city, query, limit),
+        summarizer=lambda *args, **kwargs: "",
+    )
+
+    summary = _summary_text(res.message)
+    assert _length(summary) >= 300
+
+
+def test_overlong_generation_is_truncated(summary_env, monkeypatch):
+    session = {}
+
+    def fake_generate(prompt_cfg):
+        sentence = "五島列島の魅力を紹介します。[[1]]"
+        return sentence * 120
+
+    monkeypatch.setattr(pamphlet_rag, "_generate_with_constraints", fake_generate)
+
+    res = pamphlet_flow.build_response(
+        "五島市で長い説明をお願い",
+        user_id="s3",
+        session_store=session,
+        topk=1,
+        ttl=600,
+        searcher=lambda city, query, limit: pamphlet_search.search(city, query, limit),
+        summarizer=lambda *args, **kwargs: "",
+    )
+
+    summary = _summary_text(res.message)
+    length = _length(summary)
+    assert length <= 800
+    assert summary.endswith("]]")


### PR DESCRIPTION
## Summary
- introduce an explicit route selector and log routing/antiflood decisions so special, tourism, and pamphlet handlers execute in the mandated order
- harden inbound duplicate guards with message-id replay tracking and ensure control commands resume immediately
- enforce labelled pamphlet responses within the configured length bounds and document the new operations/tests in the README

## Testing
- pytest tests/test_routing_priority.py tests/test_citations_guard.py tests/test_summary_length.py tests/test_controls_antiflood.py
- pytest *(fails: container lacks Flask/Pillow/dotenv/werkzeug dependencies required by legacy smoke suites)*

------
https://chatgpt.com/codex/tasks/task_e_68d758a4f2cc832c9b93bd66cb71c99f