### PR TITLE
feat: add adaptive pamphlet planning and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ pip install -r requirements.txt
 | `CITATION_MIN_SCORE` | `0.15` | 検索スコア合算の下限。`CITATION_MIN_CHARS` を満たさなくてもスコアが基準を超えれば出典採用 |
 | `ANTIFLOOD_TTL_SEC` | `120` | 入力・出力の短時間重複を抑止するTTL（秒） |
 | `REPLAY_GUARD_SEC` | `150` | LINE webhook の遅延イベントを無視するしきい値（秒） |
-| `SUMMARY_STYLE` | `polite_long` | パンフレット要約の文体。`polite_long` は丁寧長文モード |
+| `SUMMARY_STYLE` | `polite_long` | パンフレット要約の文体（`SUMMARY_MODE`=legacy用）。|
 | `SUMMARY_MIN_CHARS` | `550` | 通常コンテキスト時の要約下限文字数 |
 | `SUMMARY_MAX_CHARS` | `800` | 要約の上限文字数（句点で丸める） |
 | `SUMMARY_MIN_FALLBACK` | `300` | コンテキストが少ない場合の最低文字数 |
+| `SUMMARY_MODE` | `adaptive` | 回答長の自動調整モード。`adaptive`/`terse`/`long` を選択 |
 | `CONTROL_CMD_ENABLED` | `true` | 「停止」「解除」コマンドの有効/無効 |
 | `ENABLE_EVIDENCE_TOGGLE` | `true` | Web UI で根拠付き本文のトグルを表示するかどうか |
 
@@ -74,6 +75,7 @@ pip install -r requirements.txt
 - 出典欄には実際に本文で参照したドキュメントだけが並び、`CITATION_MIN_CHARS` / `CITATION_MIN_SCORE` の閾値で自動的にフィルタリングされます。
 - しきい値を下げると出典が増え、上げるとノイズを抑えられます。運用環境に合わせて `.env` で調整してください。
 - LLMがラベルを生成できなかった場合は本文末尾に注意書きが自動で追加され、出典表示は非表示になります。
+- `SUMMARY_MODE=adaptive` にすると質問意図から short/medium/long を自動選択し、2〜4文から最大800字まで出し分けます。
 
 ### 6. 入力ガードと自動返信抑止
 

--- a/services/message_builder.py
+++ b/services/message_builder.py
@@ -118,7 +118,7 @@ def parse_pamphlet_answer(raw: str) -> PamphletAnswer:
 
 
 def _expand_summary(base: str, details: Sequence[str]) -> tuple[str, int]:
-    if get_summary_style() == "polite_long":
+    if get_summary_style() in {"polite_long", "adaptive"}:
         return (base or "").strip(), 0
 
     sentences = _split_sentences(base)
@@ -166,7 +166,7 @@ def build_pamphlet_message(
 
     style = get_summary_style()
 
-    if style == "polite_long":
+    if style in {"polite_long", "adaptive"}:
         summary_candidate = summary_text.strip()
         if not summary_candidate:
             fallback = _ensure_sentence(answer.summary)

--- a/services/pamphlet_planner.py
+++ b/services/pamphlet_planner.py
@@ -1,0 +1,215 @@
+"""Intent and style planner for pamphlet answers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+
+_QUESTION_PREFIX = re.compile(r"^(?:[A-Za-z]+|[\wぁ-んァ-ン一-龠々〆ゝゞ]+)[:：]\s*")
+_WH_WORDS = {"いつ", "どこ", "何", "なに", "なぜ", "どう", "どんな", "どの", "だれ", "誰"}
+_FACT_HINTS = {
+    "いつ",
+    "どこ",
+    "時期",
+    "期間",
+    "開催日",
+    "何年",
+    "年代",
+    "誰",
+    "だれ",
+    "料金",
+    "値段",
+    "費用",
+    "アクセス",
+    "行き方",
+    "所要",
+    "時間",
+    "住所",
+    "電話",
+    "人数",
+    "規模",
+}
+_DETAIL_HINTS = {
+    "詳しく",
+    "ポイント",
+    "楽しみ方",
+    "モデルコース",
+    "おすすめ",
+    "初めて",
+    "注意点",
+    "過ごし方",
+    "体験",
+    "計画",
+    "見どころ",
+    "魅力",
+}
+_LIST_HINTS = {"一覧", "リスト"}
+_COMPARE_HINTS = {"違い", "比較", "比べ"}
+_HOWTO_HINTS = {"どうやって", "方法", "行き方", "アクセス", "参加", "申し込み"}
+
+_STOPWORDS = {
+    "について",
+    "こと",
+    "もの",
+    "教えて",
+    "ください",
+    "出来ます",
+    "できます",
+    "です",
+    "ます",
+    "よう",
+    "したい",
+    "下さい",
+    "ください",
+    "とは",
+    "を",
+    "が",
+    "は",
+    "に",
+    "で",
+    "と",
+    "へ",
+    "も",
+    "の",
+    "や",
+    "より",
+    "など",
+    "って",
+    "ってる",
+}
+
+
+@dataclass
+class Plan:
+    intent: str
+    scope: Dict[str, List[str]]
+    style: str
+    sections: List[str]
+    clarification: Optional[str] = None
+    query: str = ""
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "intent": self.intent,
+            "scope": dict(self.scope),
+            "style": self.style,
+            "sections": list(self.sections),
+            "clarification": self.clarification,
+            "query": self.query,
+        }
+
+
+def _strip_sender_prefix(text: str) -> str:
+    stripped = (text or "").strip()
+    if not stripped:
+        return ""
+    cleaned = _QUESTION_PREFIX.sub("", stripped, count=1)
+    return cleaned.strip()
+
+
+def _detect_intent(query: str) -> str:
+    text = query or ""
+    if any(token in text for token in _COMPARE_HINTS):
+        return "compare"
+    if any(token in text for token in _LIST_HINTS):
+        return "list"
+    if any(token in text for token in _HOWTO_HINTS):
+        return "howto"
+    if any(token in text for token in _FACT_HINTS):
+        return "fact"
+    if "概要" in text or "どんな" in text:
+        return "overview"
+    return "overview"
+
+
+def _select_style(query: str) -> str:
+    text = query or ""
+    if any(token in text for token in _DETAIL_HINTS):
+        return "long_explanatory"
+    if any(token in text for token in _FACT_HINTS):
+        return "short_direct"
+    if len(text) <= 15 and any(token in text for token in _WH_WORDS):
+        return "short_direct"
+    if "概要" in text or "まとめ" in text:
+        return "medium_structured"
+    return "medium_structured"
+
+
+def _collect_tokens(query: str) -> List[str]:
+    cleaned = re.sub(r"[\s、。,.!?！？\-ー（）()\[\]【】『』\n\r]+", " ", query or "").strip()
+    if not cleaned:
+        return []
+    matches = re.findall(r"[A-Za-z0-9一-龠々〆ヵヶぁ-んァ-ンゝゞー]{2,}", cleaned)
+    tokens: List[str] = []
+    for item in matches:
+        if item in _STOPWORDS:
+            continue
+        tokens.append(item)
+    return tokens
+
+
+def _extract_scope(query: str, ctx_meta: Optional[Dict[str, str]] = None) -> Dict[str, List[str]]:
+    scope: Dict[str, List[str]] = {}
+    tokens = _collect_tokens(query)
+    keywords: List[str] = []
+    for token in tokens:
+        if token in _WH_WORDS or token in _STOPWORDS:
+            continue
+        if len(token) <= 1:
+            continue
+        keywords.append(token)
+    if keywords:
+        scope["keywords"] = keywords
+
+    eras = re.findall(r"(奈良|平安|鎌倉|室町|江戸|明治|大正|昭和|平成|令和)", query)
+    years = re.findall(r"[0-9]{3,4}年", query)
+    time_scope: List[str] = []
+    if eras:
+        time_scope.extend(sorted(set(eras)))
+    if years:
+        time_scope.extend(sorted(set(years)))
+    if time_scope:
+        scope["time"] = time_scope
+
+    if ctx_meta and ctx_meta.get("city"):
+        scope.setdefault("city", [ctx_meta["city"]])
+
+    return scope
+
+
+def _choose_sections(style: str, intent: str) -> List[str]:
+    if style == "short_direct":
+        return ["結論", "補足"]
+    if style == "medium_structured":
+        return ["結論", "要点", "補足"]
+    if style == "long_explanatory":
+        if intent == "howto":
+            return ["結論", "手順", "注意"]
+        return ["結論", "要点", "注意"]
+    return ["結論"]
+
+
+def plan_answer(query: str, ctx_meta: Optional[Dict[str, str]] = None) -> Plan:
+    stripped = _strip_sender_prefix(query)
+    intent = _detect_intent(stripped)
+    style = _select_style(stripped)
+    scope = _extract_scope(stripped, ctx_meta)
+    sections = _choose_sections(style, intent)
+    clarification: Optional[str] = None
+    if not (ctx_meta or {}).get("city"):
+        clarification = "city"
+
+    return Plan(
+        intent=intent,
+        scope=scope,
+        style=style,
+        sections=sections,
+        clarification=clarification,
+        query=stripped,
+    )
+
+
+__all__ = ["Plan", "plan_answer"]
+

--- a/services/summary_config.py
+++ b/services/summary_config.py
@@ -5,6 +5,7 @@ import os
 from dataclasses import dataclass
 
 _DEFAULT_STYLE = "polite_long"
+_DEFAULT_MODE = "adaptive"
 _DEFAULT_MIN = 550
 _DEFAULT_MAX = 800
 _DEFAULT_FALLBACK = 300
@@ -17,11 +18,28 @@ class SummaryBounds:
     is_short_context: bool
 
 
+def get_summary_mode() -> str:
+    """Return the current summary mode."""
+    value = os.getenv("SUMMARY_MODE", _DEFAULT_MODE)
+    value = (value or "").strip().lower()
+    if value in {"adaptive", "terse", "long"}:
+        return value
+    return _DEFAULT_MODE
+
+
 def get_summary_style() -> str:
     """Return the configured summary style."""
-    value = os.getenv("SUMMARY_STYLE", _DEFAULT_STYLE)
-    value = (value or "").strip().lower()
-    return value or _DEFAULT_STYLE
+    override = os.getenv("SUMMARY_STYLE")
+    if override:
+        value = override.strip().lower()
+        if value:
+            return value
+    mode = get_summary_mode()
+    if mode == "terse":
+        return "terse"
+    if mode == "long":
+        return "polite_long"
+    return "adaptive"
 
 
 def _read_int(name: str, default: int) -> int:

--- a/tests/test_adaptive_length.py
+++ b/tests/test_adaptive_length.py
@@ -1,0 +1,70 @@
+import re
+
+import pytest
+
+from services import pamphlet_rag, pamphlet_search
+
+
+@pytest.fixture
+def adaptive_env(tmp_path, monkeypatch):
+    base = tmp_path / "pamphlets"
+    (base / "goto").mkdir(parents=True, exist_ok=True)
+    text = (
+        "五島市の歴史をまとめたパンフレットです。遣唐使が寄港した804年の記録や"
+        "福江港の開港について説明しています。初めて訪れる方向けの見どころも紹介しています。"
+    ) * 10
+    (base / "goto" / "history.txt").write_text(text, encoding="utf-8")
+
+    monkeypatch.setenv("SUMMARY_MODE", "adaptive")
+    monkeypatch.setenv("CITATION_MIN_CHARS", "0")
+    monkeypatch.setenv("CITATION_MIN_SCORE", "0")
+
+    pamphlet_search.configure(
+        {
+            "PAMPHLET_BASE_DIR": str(base),
+            "PAMPHLET_CHUNK_SIZE": 400,
+            "PAMPHLET_CHUNK_OVERLAP": 40,
+        }
+    )
+    pamphlet_search.reindex_all()
+
+    yield
+
+
+def _fake_generate(prompt_cfg):
+    style = prompt_cfg.style
+    if style == "short_direct":
+        return "遣唐使の寄港地として知られています[[1]] 奈良時代の交流が残ります[[1]]"
+    if style == "medium_structured":
+        return "奈良時代の役割を紹介します[[1]]\n- 港の役目が記されています[[1]]"
+    return (
+        "遣唐使との交流背景を説明します[[1]]\n"
+        "奈良時代からの歴史や見どころを2文でまとめます[[1]]"
+    )
+
+
+def test_short_direct_is_two_sentences(adaptive_env, monkeypatch):
+    monkeypatch.setattr(pamphlet_rag, "_generate_with_constraints", _fake_generate)
+    answer = pamphlet_rag.answer_from_pamphlets("開港はいつ？", "goto")
+    labelled = answer.get("answer_with_labels", "")
+    assert answer["debug"]["plan"]["style"] == "short_direct"
+    assert 1 <= labelled.count("[[") <= 2
+    assert len(labelled) <= 220
+
+
+def test_medium_structured_contains_bullet(adaptive_env, monkeypatch):
+    monkeypatch.setattr(pamphlet_rag, "_generate_with_constraints", _fake_generate)
+    answer = pamphlet_rag.answer_from_pamphlets("歴史の概要を教えて", "goto")
+    labelled = answer.get("answer_with_labels", "")
+    assert answer["debug"]["plan"]["style"] == "medium_structured"
+    assert "\n- " in labelled
+
+
+def test_long_explanatory_two_paragraphs(adaptive_env, monkeypatch):
+    monkeypatch.setattr(pamphlet_rag, "_generate_with_constraints", _fake_generate)
+    answer = pamphlet_rag.answer_from_pamphlets("初めて行くので詳しく知りたい", "goto")
+    labelled = answer.get("answer_with_labels", "")
+    assert answer["debug"]["plan"]["style"] == "long_explanatory"
+    paragraphs = [p for p in labelled.split("\n") if p.strip()]
+    assert len(paragraphs) <= 4
+    assert len(labelled) <= 800

--- a/tests/test_intent_detection.py
+++ b/tests/test_intent_detection.py
@@ -1,0 +1,18 @@
+from services.pamphlet_planner import plan_answer
+
+
+def test_fact_question_prefers_short_direct():
+    plan = plan_answer("開園はいつですか？", {"city": "goto"})
+    assert plan.intent == "fact"
+    assert plan.style == "short_direct"
+
+
+def test_overview_question_prefers_medium():
+    plan = plan_answer("福江城について概要を教えて", {"city": "goto"})
+    assert plan.intent == "overview"
+    assert plan.style == "medium_structured"
+
+
+def test_detail_request_prefers_long():
+    plan = plan_answer("初めて行くのでモデルコースを詳しく知りたい", {"city": "goto"})
+    assert plan.style == "long_explanatory"

--- a/tests/test_routing_integration.py
+++ b/tests/test_routing_integration.py
@@ -1,0 +1,49 @@
+from services.route_selector import select_route
+
+
+def test_priority_order_respected():
+    calls = []
+
+    def special_probe(text):
+        calls.append("special")
+        return False
+
+    def tourism_probe(text):
+        calls.append("tourism")
+        return False
+
+    def pamphlet_probe(text):
+        calls.append("pamphlet")
+        return True, {"city": "goto"}
+
+    decision = select_route(
+        "五島市の歴史を教えて",
+        special_probe=special_probe,
+        tourism_probe=tourism_probe,
+        pamphlet_probe=pamphlet_probe,
+    )
+
+    assert decision.route == "pamphlet"
+    assert calls == ["special", "tourism", "pamphlet"]
+
+
+def test_special_short_circuits_following_probes():
+    calls = []
+
+    def special_probe(text):
+        calls.append("special")
+        return True
+
+    def tourism_probe(text):
+        calls.append("tourism")
+        return True
+
+    decision = select_route(
+        "天気を教えて",
+        special_probe=special_probe,
+        tourism_probe=tourism_probe,
+        pamphlet_probe=lambda _: True,
+    )
+
+    assert decision.route == "special"
+    assert calls == ["special"]

--- a/tests/test_sender_name_strip.py
+++ b/tests/test_sender_name_strip.py
@@ -1,0 +1,7 @@
+from services.pamphlet_planner import plan_answer
+
+
+def test_sender_prefix_removed():
+    plan = plan_answer("User: 開催はいつ？", {"city": "goto"})
+    assert plan.query == "開催はいつ？"
+    assert plan.style == "short_direct"

--- a/tests/test_source_guard.py
+++ b/tests/test_source_guard.py
@@ -1,0 +1,20 @@
+from services.pamphlet_rag import CitationRef, postprocess_answer
+
+
+def test_invalid_labels_removed_from_answer():
+    ref = CitationRef(
+        doc_id="goto/guide.txt",
+        chunk_id="1",
+        title="guide",
+        city="五島市",
+        start_offset=0,
+        end_offset=100,
+        score=1.0,
+        text="五島市の歴史は奈良時代に遣唐使の寄港地となったことに始まります。",
+    )
+    id_map = {1: ref}
+    result = postprocess_answer("奈良時代の寄港地でした[[1]] 新情報です[[2]]", id_map, min_chars=0, min_score=0)
+
+    assert result.used_labels == [1]
+    assert "[[2]]" not in result.answer_with_labels
+    assert result.citations[0]["labels"] == [1]


### PR DESCRIPTION
## Summary
- add a dedicated planner that infers intent, scope, and adaptive styles for pamphlet answers
- refresh the RAG prompt, retrieval filters, and message builder to honor adaptive short/medium/long outputs and synonym-based query expansion
- document the new SUMMARY_MODE setting and cover the behaviour with new unit and integration tests

## Testing
- pytest tests/test_intent_detection.py tests/test_source_guard.py tests/test_adaptive_length.py tests/test_sender_name_strip.py tests/test_routing_integration.py
- pytest tests/test_summary_length.py


------
https://chatgpt.com/codex/tasks/task_e_68d7717368c0832cb39d147b29c0445f