### PR TITLE
Add responder skeleton modules for future refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@
 !tests/**
 !scripts/
 !scripts/**
+# app responder skeleton
+!app/
+!app/**
 # GitHub workflow
 !.github/
 !.github/**

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,20 @@
+"""Application package initialization."""
+
+# Explicitly define the modules that make up the new responder skeleton.
+from . import config, intent, llm, schemas  # noqa: F401
+from .responders import entries, fallback, pamphlet, priority  # noqa: F401
+from .search import entries_index, normalize, pamphlet_index  # noqa: F401
+
+__all__ = [
+    "config",
+    "intent",
+    "llm",
+    "schemas",
+    "entries",
+    "fallback",
+    "pamphlet",
+    "priority",
+    "entries_index",
+    "normalize",
+    "pamphlet_index",
+]

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,12 @@
+"""Centralized configuration for the application."""
+from __future__ import annotations
+
+import os
+from typing import Final
+
+# TODO: wire these constants into the runtime configuration once the new
+# responder framework is implemented.
+MODEL_DEFAULT: Final[str] = os.getenv("MODEL_DEFAULT", "gpt-4o-mini")
+MODEL_HARD: Final[str] = os.getenv("MODEL_HARD", "gpt-5-mini")
+
+__all__ = ["MODEL_DEFAULT", "MODEL_HARD"]

--- a/app/intent.py
+++ b/app/intent.py
@@ -1,0 +1,25 @@
+"""Intent detection skeleton module."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class IntentDetector:
+    """Placeholder intent detector.
+
+    TODO: Replace with real intent classification logic when the responder
+    refactor is implemented.
+    """
+
+    def detect(self, message: str, *, context: Dict[str, Any] | None = None) -> str:
+        """Return a dummy intent label for the given message."""
+        _ = (message, context)
+        return "fallback"
+
+
+def get_intent_detector() -> IntentDetector:
+    """Factory for the intent detector."""
+    return IntentDetector()
+
+
+__all__ = ["IntentDetector", "get_intent_detector"]

--- a/app/llm.py
+++ b/app/llm.py
@@ -1,0 +1,31 @@
+"""LLM client skeleton module."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class LLMRequest:
+    """Data required to make an LLM call."""
+
+    prompt: str
+    parameters: Dict[str, Any] | None = None
+
+
+class LLMClient:
+    """Placeholder large language model client."""
+
+    def complete(self, request: LLMRequest) -> str:
+        """Return a dummy completion string."""
+        _ = request
+        # TODO: Integrate with the configured LLM provider.
+        return "[llm response placeholder]"
+
+
+def get_llm_client() -> LLMClient:
+    """Factory for the LLM client."""
+    return LLMClient()
+
+
+__all__ = ["LLMClient", "LLMRequest", "get_llm_client"]

--- a/app/responders/__init__.py
+++ b/app/responders/__init__.py
@@ -1,0 +1,14 @@
+"""Responder package exposing placeholder responders."""
+from __future__ import annotations
+
+from .entries import EntriesResponder
+from .fallback import FallbackResponder
+from .pamphlet import PamphletResponder
+from .priority import PriorityResponder
+
+__all__ = [
+    "EntriesResponder",
+    "FallbackResponder",
+    "PamphletResponder",
+    "PriorityResponder",
+]

--- a/app/responders/entries.py
+++ b/app/responders/entries.py
@@ -1,0 +1,17 @@
+"""Entries responder skeleton."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class EntriesResponder:
+    """Placeholder responder for entries-based interactions."""
+
+    def respond(self, message: str, *, context: Dict[str, Any] | None = None) -> str:
+        """Return a dummy response for entry lookup."""
+        _ = (message, context)
+        # TODO: Implement entry lookup logic.
+        return "[entries response placeholder]"
+
+
+__all__ = ["EntriesResponder"]

--- a/app/responders/fallback.py
+++ b/app/responders/fallback.py
@@ -1,0 +1,17 @@
+"""Fallback responder skeleton."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class FallbackResponder:
+    """Placeholder responder for unmatched intents."""
+
+    def respond(self, message: str, *, context: Dict[str, Any] | None = None) -> str:
+        """Return a dummy fallback response."""
+        _ = (message, context)
+        # TODO: Implement graceful fallback behavior.
+        return "[fallback response placeholder]"
+
+
+__all__ = ["FallbackResponder"]

--- a/app/responders/pamphlet.py
+++ b/app/responders/pamphlet.py
@@ -1,0 +1,17 @@
+"""Pamphlet responder skeleton."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class PamphletResponder:
+    """Placeholder responder for pamphlet queries."""
+
+    def respond(self, message: str, *, context: Dict[str, Any] | None = None) -> str:
+        """Return a dummy response for pamphlet-related queries."""
+        _ = (message, context)
+        # TODO: Implement pamphlet retrieval logic.
+        return "[pamphlet response placeholder]"
+
+
+__all__ = ["PamphletResponder"]

--- a/app/responders/priority.py
+++ b/app/responders/priority.py
@@ -1,0 +1,17 @@
+"""Priority responder skeleton."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class PriorityResponder:
+    """Placeholder responder for high-priority scenarios."""
+
+    def respond(self, message: str, *, context: Dict[str, Any] | None = None) -> str:
+        """Return a dummy response for priority intents."""
+        _ = (message, context)
+        # TODO: Implement real priority response logic.
+        return "[priority response placeholder]"
+
+
+__all__ = ["PriorityResponder"]

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,24 @@
+"""Shared schemas for the responder skeleton."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass(slots=True)
+class ConversationContext:
+    """Placeholder schema for conversation state."""
+
+    user_id: str
+    metadata: Dict[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class ResponderOutput:
+    """Placeholder schema for responder outputs."""
+
+    message: str
+    intent: str
+
+
+__all__ = ["ConversationContext", "ResponderOutput"]

--- a/app/search/__init__.py
+++ b/app/search/__init__.py
@@ -1,0 +1,14 @@
+"""Search package exposing placeholder indexes."""
+from __future__ import annotations
+
+from .entries_index import EntriesIndex, load_entries_index
+from .normalize import normalize_query
+from .pamphlet_index import PamphletIndex, load_pamphlet_index
+
+__all__ = [
+    "EntriesIndex",
+    "load_entries_index",
+    "normalize_query",
+    "PamphletIndex",
+    "load_pamphlet_index",
+]

--- a/app/search/entries_index.py
+++ b/app/search/entries_index.py
@@ -1,0 +1,23 @@
+"""Entries search index skeleton."""
+from __future__ import annotations
+
+from typing import Any, Iterable, List
+
+
+class EntriesIndex:
+    """Placeholder in-memory index for entries."""
+
+    def search(self, query: str) -> List[Any]:
+        """Return dummy search results for entries."""
+        _ = query
+        # TODO: Replace with actual search implementation.
+        return []
+
+
+def load_entries_index(_: Iterable[Any] | None = None) -> EntriesIndex:
+    """Factory for entries index instances."""
+    # TODO: Load real data once the refactor lands.
+    return EntriesIndex()
+
+
+__all__ = ["EntriesIndex", "load_entries_index"]

--- a/app/search/normalize.py
+++ b/app/search/normalize.py
@@ -1,0 +1,16 @@
+"""Text normalization helpers for search modules."""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def normalize_query(tokens: Iterable[str]) -> list[str]:
+    """Return a normalized token list.
+
+    TODO: Implement proper normalization once search is refactored.
+    """
+
+    return [token.lower() for token in tokens]
+
+
+__all__ = ["normalize_query"]

--- a/app/search/pamphlet_index.py
+++ b/app/search/pamphlet_index.py
@@ -1,0 +1,23 @@
+"""Pamphlet search index skeleton."""
+from __future__ import annotations
+
+from typing import Any, Iterable, List
+
+
+class PamphletIndex:
+    """Placeholder in-memory index for pamphlets."""
+
+    def search(self, query: str) -> List[Any]:
+        """Return dummy search results for pamphlets."""
+        _ = query
+        # TODO: Replace with actual search implementation.
+        return []
+
+
+def load_pamphlet_index(_: Iterable[Any] | None = None) -> PamphletIndex:
+    """Factory for pamphlet index instances."""
+    # TODO: Load real data once the refactor lands.
+    return PamphletIndex()
+
+
+__all__ = ["PamphletIndex", "load_pamphlet_index"]

--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -1,0 +1,32 @@
+"""Ensure the responder skeleton modules are importable."""
+
+
+def test_import_skeleton_modules() -> None:
+    """Verify that the placeholder modules can be imported."""
+    import app  # noqa: F401
+    from app import (  # noqa: F401
+        config,
+        intent,
+        llm,
+        schemas,
+    )
+    from app.responders import (  # noqa: F401
+        entries,
+        fallback,
+        pamphlet,
+        priority,
+    )
+    from app.search import entries_index, normalize, pamphlet_index  # noqa: F401
+
+    assert app is not None
+    assert config is not None
+    assert intent is not None
+    assert llm is not None
+    assert schemas is not None
+    assert entries is not None
+    assert fallback is not None
+    assert pamphlet is not None
+    assert priority is not None
+    assert entries_index is not None
+    assert normalize is not None
+    assert pamphlet_index is not None


### PR DESCRIPTION
## Summary
- add an `app` package with placeholder intent detection, responder, search, llm, schema, and config modules to prep the refactor
- expose the responder skeleton via package exports and centralize upcoming model constants
- allow the new package in version control and add a smoke test that ensures the imports succeed

## Testing
- pytest tests/test_skeleton.py

------
https://chatgpt.com/codex/tasks/task_e_68db3a784e7c832cab001c2d66cdd903