### PR TITLE
Add 2-char tourism search and persistent suspend state

### DIFF
--- a/coreapp/config.py
+++ b/coreapp/config.py
@@ -7,6 +7,7 @@ from typing import Final
 
 MODEL_DEFAULT: Final[str] = os.getenv("MODEL_DEFAULT", "gpt-4o-mini")
 MODEL_HARD: Final[str] = os.getenv("MODEL_HARD", "gpt-5-mini")
+MIN_QUERY_CHARS: Final[int] = int(os.getenv("MIN_QUERY_CHARS", "2"))
 
 THRESHOLD_SCORE_HARD: Final[float] = float(os.getenv("THRESHOLD_SCORE_HARD", "0.75"))
 THRESHOLD_PIECES_HARD: Final[int] = int(os.getenv("THRESHOLD_PIECES_HARD", "6"))
@@ -16,6 +17,7 @@ THRESHOLD_REPROMPTS_HARD: Final[int] = int(os.getenv("THRESHOLD_REPROMPTS_HARD",
 __all__ = [
     "MODEL_DEFAULT",
     "MODEL_HARD",
+    "MIN_QUERY_CHARS",
     "THRESHOLD_SCORE_HARD",
     "THRESHOLD_PIECES_HARD",
     "THRESHOLD_REPROMPTS_HARD",

--- a/coreapp/intent.py
+++ b/coreapp/intent.py
@@ -1,6 +1,5 @@
 """Intent detection helpers for the responder skeleton."""
 from __future__ import annotations
-
 from dataclasses import dataclass
 import re
 import unicodedata
@@ -19,6 +18,60 @@ def normalize_for_matching(text: str | None) -> str:
     """Public helper exposing the normalisation used for intent checks."""
 
     return _normalize(text)
+
+
+# --- Pause / resume commands ---------------------------------------------
+
+_PAUSE_COMMANDS: tuple[str, ...] = tuple(
+    _normalize(token)
+    for token in (
+        "停止",
+        "一時停止",
+        "ストップ",
+        "ミュート",
+        "pause",
+        "stop",
+    )
+)
+
+_RESUME_COMMANDS: tuple[str, ...] = tuple(
+    _normalize(token)
+    for token in (
+        "解除",
+        "再開",
+        "応答再開",
+        "ミュート解除",
+        "resume",
+        "unpause",
+    )
+)
+
+
+def _matches_command(text: str, commands: Iterable[str]) -> bool:
+    for keyword in commands:
+        if not keyword:
+            continue
+        if text == keyword or text.startswith(f"{keyword} "):
+            return True
+    return False
+
+
+def is_pause_command(text: str | None) -> bool:
+    """Return ``True`` if the text requests conversation suspension."""
+
+    normalized = _normalize(text)
+    if not normalized:
+        return False
+    return _matches_command(normalized, _PAUSE_COMMANDS)
+
+
+def is_resume_command(text: str | None) -> bool:
+    """Return ``True`` if the text asks to resume a suspended conversation."""
+
+    normalized = _normalize(text)
+    if not normalized:
+        return False
+    return _matches_command(normalized, _RESUME_COMMANDS)
 
 
 # --- Priority trigger dictionaries ---------------------------------------
@@ -177,6 +230,8 @@ __all__ = [
     "TRANSPORT_VEHICLE_KEYWORDS",
     "WEATHER_KEYWORDS",
     "get_intent_detector",
+    "is_pause_command",
+    "is_resume_command",
     "is_transport_query",
     "normalize_for_matching",
     "is_viewpoint_map_query",

--- a/coreapp/state.py
+++ b/coreapp/state.py
@@ -1,0 +1,113 @@
+"""Simple persistence helpers for per-user suspension flags."""
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Iterator
+
+import fcntl
+
+from services.paths import get_data_base_dir
+
+_STATE_DIR_NAME = "state"
+_STATE_FILE_NAME = "suspend.json"
+
+
+def _state_dir() -> Path:
+    base = get_data_base_dir(None)
+    directory = base / _STATE_DIR_NAME
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _state_file() -> Path:
+    path = _state_dir() / _STATE_FILE_NAME
+    if not path.exists():
+        path.write_text("{}", encoding="utf-8")
+    return path
+
+
+def _hash_user_id(user_id: str) -> str:
+    import hashlib
+
+    digest = hashlib.sha256(user_id.encode("utf-8")).hexdigest()
+    return digest
+
+
+def _load_state(handle) -> Dict[str, bool]:
+    handle.seek(0)
+    raw = handle.read()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    cleaned: Dict[str, bool] = {}
+    for key, value in data.items():
+        if isinstance(key, str):
+            cleaned[key] = bool(value)
+    return cleaned
+
+
+def _dump_state(handle, state: Dict[str, bool]) -> None:
+    handle.seek(0)
+    json.dump(state, handle, ensure_ascii=False, sort_keys=True)
+    handle.truncate()
+    handle.flush()
+    os.fsync(handle.fileno())
+
+
+@contextmanager
+def _locked_state() -> Iterator[Dict[str, bool]]:
+    path = _state_file()
+    with path.open("r+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            state = _load_state(handle)
+            yield state
+            _dump_state(handle, state)
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def suspend_user(user_id: str) -> None:
+    if not user_id:
+        return
+    hashed = _hash_user_id(user_id)
+    with _locked_state() as state:
+        state[hashed] = True
+
+
+def resume_user(user_id: str) -> None:
+    if not user_id:
+        return
+    hashed = _hash_user_id(user_id)
+    with _locked_state() as state:
+        state[hashed] = False
+
+
+def is_suspended(user_id: str) -> bool:
+    if not user_id:
+        return False
+    path = _state_file()
+    with path.open("r", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_SH)
+        try:
+            state = _load_state(handle)
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    hashed = _hash_user_id(user_id)
+    return bool(state.get(hashed))
+
+
+def reset_for_tests() -> None:
+    path = _state_file()
+    path.write_text("{}", encoding="utf-8")
+
+
+__all__ = ["suspend_user", "resume_user", "is_suspended", "reset_for_tests"]

--- a/tests/test_entries_2char.py
+++ b/tests/test_entries_2char.py
@@ -1,0 +1,47 @@
+from coreapp.responders.entries import EntriesResponder
+from coreapp.search.entries_index import load_entries_index
+
+
+MULTI_ENTRIES = [
+    {"id": "spot-1", "title": "教会資料館", "desc": "教会群の資料を展示"},
+    {"id": "spot-2", "title": "堂崎教会", "kana": "どうざききょうかい"},
+    {"id": "spot-3", "title": "青砂ヶ浦天主堂", "desc": "長崎の教会群の一つ"},
+    {"id": "spot-4", "title": "旧五輪教会堂", "desc": "世界遺産の教会です"},
+    {"id": "spot-5", "title": "福江観光案内所", "desc": "教会巡りの相談窓口"},
+    {"id": "spot-6", "title": "巡礼ツアーセンター", "tags": ["教会", "ツアー"]},
+    {"id": "spot-7", "title": "高浜ビーチカフェ", "desc": "海沿いのカフェ"},
+]
+
+SINGLE_ENTRY = [
+    {
+        "id": "single-1",
+        "title": "江上天主堂",
+        "desc": "世界遺産の教会です。",
+        "areas": ["上五島"],
+    }
+]
+
+
+def test_two_char_query_hits_and_limit():
+    index = load_entries_index(MULTI_ENTRIES)
+    results = index.search("教会")
+
+    assert results, "2文字のクエリでヒットが返ること"
+    assert len(results) <= 5, "2文字クエリでは最大5件に制限される"
+    titles = [match.entry.get("title") for match in results]
+    assert titles[0] == "教会資料館"
+    assert titles[1] == "堂崎教会"
+
+
+def test_one_char_query_is_ignored():
+    index = load_entries_index(MULTI_ENTRIES)
+    assert index.search("教") == []
+
+
+def test_two_char_single_hit_returns_detail():
+    responder = EntriesResponder(index=load_entries_index(SINGLE_ENTRY))
+    context: dict = {}
+    result = responder.respond("教会", context=context)
+
+    assert result.kind == "detail"
+    assert "教会" in result.message

--- a/tests/test_pause_resume.py
+++ b/tests/test_pause_resume.py
@@ -1,0 +1,65 @@
+import importlib
+import logging
+
+
+def test_suspend_resume_persistence(tmp_path, monkeypatch):
+    base_dir = tmp_path / "data"
+    monkeypatch.setenv("DATA_BASE_DIR", str(base_dir))
+    monkeypatch.setenv("USER_STATE_DB_PATH", str(tmp_path / "user_state.sqlite"))
+    monkeypatch.setenv("CONTROL_CMD_ENABLED", "true")
+    monkeypatch.setenv("PAUSE_DEFAULT_TTL_SEC", "60")
+
+    state_module = importlib.import_module("coreapp.state")
+    state = importlib.reload(state_module)
+    state.reset_for_tests()
+
+    handlers_module = importlib.import_module("services.line_handlers")
+    handlers = importlib.reload(handlers_module)
+
+    user_id = "U123"
+    state.suspend_user(user_id)
+    assert state.is_suspended(user_id) is True
+    assert handlers.control_is_paused(user_id, 0) is True
+
+    # Persistence across reload
+    state = importlib.reload(state)
+    assert state.is_suspended(user_id) is True
+
+    state.resume_user(user_id)
+    assert state.is_suspended(user_id) is False
+    assert handlers.control_is_paused(user_id, 0) is False
+
+    # Suspend again via the control command to ensure both stores are updated
+    pause_replies: list[str] = []
+
+    handlers.process_control_command(
+        "停止",
+        user_id=user_id,
+        event=None,
+        reply_func=lambda _event, message: pause_replies.append(message),
+        logger=logging.getLogger("test"),
+        now=240,
+    )
+
+    assert state.is_suspended(user_id) is True
+    assert handlers.control_is_paused(user_id, 0) is True
+
+    replies: list[str] = []
+
+    def fake_reply(_event, message):
+        replies.append(message)
+        return message
+
+    result = handlers.process_control_command(
+        "解除",
+        user_id=user_id,
+        event=None,
+        reply_func=fake_reply,
+        logger=logging.getLogger("test"),
+        now=260,
+    )
+
+    assert result["action"] == "resume"
+    assert state.is_suspended(user_id) is False
+    assert handlers.control_is_paused(user_id, 0) is False
+    assert any("再開しました" in message for message in replies)


### PR DESCRIPTION
## Summary
- allow tourism entry search to accept 2-character queries with improved scoring and limits to reduce noise
- add a JSON-backed suspension store and hook pause/resume commands so conversations resume immediately after "解除"
- cover the new behaviours with dedicated search and pause/resume tests

## Testing
- `pytest tests/test_entries.py tests/test_entries_2char.py tests/test_control_commands.py tests/test_pause_resume.py`


------
https://chatgpt.com/codex/tasks/task_e_68dba6f1ccd8832c9f977f66ed59b022