### PR TITLE
Guard pamphlet bootstrap and secure backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ pip install -r requirements.txt
 
 | 変数名 | 既定値 | 説明 |
 | ------ | ------ | ---- |
+| `DATA_BASE_DIR` | `/var/data` | 永続ディスクのルートディレクトリ |
 | `PAMPHLET_BASE_DIR` | `/var/data/pamphlets` | パンフレットテキストの格納ルート |
+| `SEED_PAMPHLET_DIR` | `<repo>/seeds/pamphlets` | 初回起動時にコピーするシードデータ（任意） |
+| `ADMIN_TOKEN` | （空文字） | `/ops/backup/pamphlets` への保護用トークン。設定時は `X-Admin-Token` ヘッダで送信 |
 | `PAMPHLET_TOPK` | `3` | 要約に渡す上位チャンク数 |
 | `PAMPHLET_CHUNK_SIZE` | `1500` | チャンク長（文字数） |
 | `PAMPHLET_CHUNK_OVERLAP` | `200` | チャンク重複幅（文字数） |
@@ -73,6 +76,8 @@ pip install -r requirements.txt
 | `ENABLE_EVIDENCE_TOGGLE` | `true` | Web UI で根拠付き本文のトグルを表示するかどうか |
 
 アップロードは 64MB まで受け付けますが、ブラウザからの編集保存は軽量テキスト運用を想定して 2MB で上限判定します。
+
+- `/var/data/pamphlets` が空の場合は `seeds/pamphlets` 配下の初期データを自動コピーします。既存の `pamphlets/`、`data/pamphlets/`、`static/pamphlets/` にある `.txt` は初回起動時に `/var/data/pamphlets` へ移行されます。
 
 ### 5. 出典ラベル付きRAG応答
 

--- a/coreapp/config.py
+++ b/coreapp/config.py
@@ -2,8 +2,19 @@
 from __future__ import annotations
 
 import os
+import pathlib
 from typing import Final
 
+
+DATA_BASE_DIR: Final[str] = os.getenv("DATA_BASE_DIR", "/var/data")
+PAMPHLET_BASE_DIR: Final[str] = os.getenv(
+    "PAMPHLET_BASE_DIR",
+    os.path.join(DATA_BASE_DIR, "pamphlets"),
+)
+SEED_PAMPHLET_DIR: Final[str] = os.getenv(
+    "SEED_PAMPHLET_DIR",
+    str(pathlib.Path(os.getcwd()) / "seeds" / "pamphlets"),
+)
 
 MODEL_DEFAULT: Final[str] = os.getenv("MODEL_DEFAULT", "gpt-4o-mini")
 MODEL_HARD: Final[str] = os.getenv("MODEL_HARD", "gpt-5-mini")
@@ -15,6 +26,9 @@ THRESHOLD_REPROMPTS_HARD: Final[int] = int(os.getenv("THRESHOLD_REPROMPTS_HARD",
 
 
 __all__ = [
+    "DATA_BASE_DIR",
+    "PAMPHLET_BASE_DIR",
+    "SEED_PAMPHLET_DIR",
     "MODEL_DEFAULT",
     "MODEL_HARD",
     "MIN_QUERY_CHARS",

--- a/coreapp/storage.py
+++ b/coreapp/storage.py
@@ -1,0 +1,174 @@
+"""Helpers for managing persistent storage directories."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import os
+import shutil
+import tarfile
+import tempfile
+from typing import Dict, Iterable
+
+from coreapp import config as cfg
+
+
+BASE_DIR = Path(cfg.DATA_BASE_DIR)
+PAMPHLETS_DIR = Path(cfg.PAMPHLET_BASE_DIR)
+BACKUPS_DIR = BASE_DIR / "backups"
+_LEGACY_SENTINEL = BASE_DIR / ".pamphlets_legacy_migrated"
+
+
+def ensure_dirs() -> None:
+    """Ensure persistent directories are present."""
+
+    for directory in (BASE_DIR, PAMPHLETS_DIR, BACKUPS_DIR):
+        directory.mkdir(parents=True, exist_ok=True)
+
+
+def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+    """Atomically write *text* to *path* preserving durability semantics."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", delete=False, encoding=encoding, dir=str(path.parent)
+    ) as tmp:
+        tmp.write(text)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp_name = tmp.name
+    os.replace(tmp_name, path)
+
+
+def _copy_txt_files(src: Path, dest: Path) -> None:
+    for item in src.rglob("*.txt"):
+        if not item.is_file():
+            continue
+        try:
+            rel = item.relative_to(src)
+        except ValueError:
+            rel = item.name
+        target = dest / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            try:
+                src_mtime = item.stat().st_mtime
+                dest_mtime = target.stat().st_mtime
+            except OSError:
+                continue
+            # Only overwrite when the source looks newer.
+            if src_mtime <= dest_mtime + 1e-6:
+                continue
+        shutil.copy2(item, target)
+
+
+def seed_from_repo_if_empty() -> None:
+    """Seed pamphlets from the repository when the directory is empty."""
+
+    ensure_dirs()
+    seed_dir = Path(cfg.SEED_PAMPHLET_DIR)
+    if not seed_dir.exists():
+        return
+    has_txt = any(PAMPHLETS_DIR.rglob("*.txt"))
+    if has_txt:
+        return
+    _copy_txt_files(seed_dir, PAMPHLETS_DIR)
+
+
+def migrate_from_legacy_paths() -> None:
+    """Rescue pamphlet files from historical locations once."""
+
+    ensure_dirs()
+    if _LEGACY_SENTINEL.exists():
+        return
+
+    migrated = False
+    candidates = [
+        Path("pamphlets"),
+        Path("data/pamphlets"),
+        Path("static/pamphlets"),
+    ]
+    for src in candidates:
+        if not src.exists() or not any(src.rglob("*.txt")):
+            continue
+        _copy_txt_files(src, PAMPHLETS_DIR)
+        migrated = True
+
+    try:
+        if migrated:
+            _LEGACY_SENTINEL.write_text(
+                datetime.utcnow().isoformat(timespec="seconds"),
+                encoding="utf-8",
+            )
+        else:
+            _LEGACY_SENTINEL.touch()
+    except OSError:
+        # Failing to write the sentinel should not block startup.
+        pass
+
+
+def list_city_dirs() -> list[Path]:
+    """Return available city directories under the pamphlet root."""
+
+    if not PAMPHLETS_DIR.exists():
+        return []
+    return [p for p in PAMPHLETS_DIR.iterdir() if p.is_dir()]
+
+
+def iter_pamphlet_files(pattern: str = "*.txt") -> Iterable[Path]:
+    """Iterate over pamphlet files matching *pattern*."""
+
+    if not PAMPHLETS_DIR.exists():
+        return iter(())
+    return PAMPHLETS_DIR.rglob(pattern)
+
+
+def count_pamphlet_files() -> int:
+    """Return the number of pamphlet text files."""
+
+    return sum(1 for _ in iter_pamphlet_files())
+
+
+def count_pamphlets_by_city() -> Dict[str, int]:
+    """Return a mapping of city directory name to pamphlet file count."""
+
+    counts: Dict[str, int] = {}
+    if not PAMPHLETS_DIR.exists():
+        return counts
+
+    for city_dir in list_city_dirs():
+        try:
+            counts[city_dir.name] = sum(1 for _ in city_dir.rglob("*.txt"))
+        except OSError:
+            continue
+    return counts
+
+
+def create_pamphlet_backup(*, suffix: str | None = None) -> Path:
+    """Create a tar.gz backup of the pamphlet directory."""
+
+    ensure_dirs()
+    BACKUPS_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M")
+    if suffix:
+        timestamp = f"{timestamp}-{suffix}"
+    archive = BACKUPS_DIR / f"pamphlets-{timestamp}.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(PAMPHLETS_DIR, arcname="pamphlets")
+    return archive
+
+
+__all__ = [
+    "BASE_DIR",
+    "PAMPHLETS_DIR",
+    "BACKUPS_DIR",
+    "ensure_dirs",
+    "atomic_write_text",
+    "seed_from_repo_if_empty",
+    "migrate_from_legacy_paths",
+    "list_city_dirs",
+    "iter_pamphlet_files",
+    "count_pamphlet_files",
+    "count_pamphlets_by_city",
+    "create_pamphlet_backup",
+]
+

--- a/services/pamphlet_search.py
+++ b/services/pamphlet_search.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
-from config import PAMPHLET_BASE_DIR
+from coreapp.storage import PAMPHLETS_DIR
 
 
 logger = logging.getLogger(__name__)
@@ -215,7 +215,8 @@ class _PamphletIndex:
 
 class PamphletIndexManager:
     def __init__(self) -> None:
-        self.base_dir = Path(os.getenv("PAMPHLET_BASE_DIR") or PAMPHLET_BASE_DIR)
+        default_dir = os.getenv("PAMPHLET_BASE_DIR") or str(PAMPHLETS_DIR)
+        self.base_dir = Path(default_dir)
         self.chunk_size = int(os.getenv("PAMPHLET_CHUNK_SIZE", "700"))
         self.chunk_overlap = int(os.getenv("PAMPHLET_CHUNK_OVERLAP", "150"))
         self._indexes: Dict[str, _PamphletIndex] = {}

--- a/tests/test_pamphlet_persistence.py
+++ b/tests/test_pamphlet_persistence.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.utils import load_test_app
+
+
+def test_pamphlets_survive_restart(monkeypatch, tmp_path):
+    base = tmp_path / "data"
+    (base / "pamphlets" / "goto").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("DATA_BASE_DIR", str(base))
+    monkeypatch.setenv("PAMPHLET_BASE_DIR", str(base / "pamphlets"))
+
+    env = {
+        "DATA_BASE_DIR": base,
+        "PAMPHLET_BASE_DIR": base / "pamphlets",
+        "SECRET_KEY": "test",
+        "SEED_PAMPHLET_DIR": base / "no_seed",
+    }
+
+    with load_test_app(monkeypatch, tmp_path, extra_env=env) as module:
+        pamphlet_dir = Path(module.app.config["PAMPHLET_BASE_DIR"])
+        pamphlet = pamphlet_dir / "goto" / "sample.txt"
+        pamphlet.parent.mkdir(parents=True, exist_ok=True)
+        pamphlet.write_text("五島の歴史…", encoding="utf-8")
+
+    with load_test_app(monkeypatch, tmp_path, extra_env=env) as module:
+        pamphlet_dir = Path(module.app.config["PAMPHLET_BASE_DIR"])
+        pamphlet = pamphlet_dir / "goto" / "sample.txt"
+        assert pamphlet.exists()
+        assert "五島" in pamphlet.read_text(encoding="utf-8")

--- a/tests/test_readyz_endpoint.py
+++ b/tests/test_readyz_endpoint.py
@@ -22,8 +22,9 @@ def test_readyz_returns_expected_schema(monkeypatch, tmp_path):
         payload = response.get_json()
         assert payload["status"] == "ok"
         assert payload["errors"] == []
-        assert payload["warnings"] == []
+        assert "pamphlet_base_dir:empty" in payload["warnings"]
 
         details = payload["details"]
         assert details["data_base_dir"] == str(app.config["DATA_BASE_DIR"])
         assert details["pamphlet_base_dir"] == str(base_dir)
+        assert details.get("pamphlet_count") == 0

--- a/tests/test_readyz_pamphlets.py
+++ b/tests/test_readyz_pamphlets.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.utils import load_test_app
+
+
+def test_readyz_warns_when_pamphlets_empty(monkeypatch, tmp_path):
+    base = tmp_path / "data"
+    (base / "pamphlets").mkdir(parents=True)
+    (base / ".pamphlets_legacy_migrated").write_text("test", encoding="utf-8")
+    (base / ".bootstrap.done").write_text("ok", encoding="utf-8")
+
+    with load_test_app(
+        monkeypatch,
+        tmp_path,
+        extra_env={
+            "DATA_BASE_DIR": base,
+            "PAMPHLET_BASE_DIR": base / "pamphlets",
+            "SECRET_KEY": "test",
+            "SEED_PAMPHLET_DIR": base / "no_seed",
+        },
+    ) as module:
+        client = module.app.test_client()
+        pamphlet_dir = Path(module.app.config["PAMPHLET_BASE_DIR"])
+        for txt in pamphlet_dir.rglob("*.txt"):
+            txt.unlink()
+        monkeypatch.setattr(module, "count_pamphlet_files", lambda: 0, raising=False)
+        monkeypatch.setattr(module, "count_pamphlets_by_city", lambda: {}, raising=False)
+
+        response = client.get("/readyz")
+        payload = response.get_json()
+
+        assert response.status_code in (200, 503)
+        assert "warnings" in payload
+        warnings = payload["warnings"]
+        assert "pamphlet_base_dir:empty" in warnings or payload["details"].get("pamphlet_count", 0) == 0
+        assert (
+            payload["details"]["pamphlet_base_dir"]
+            == module.app.config["PAMPHLET_BASE_DIR"]
+        )
+        assert payload["details"].get("pamphlet_count_by_city", {}) in ({}, None)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -114,6 +114,7 @@ def load_test_app(monkeypatch, tmp_path, extra_env=None):
     module_name = f"app_for_test_{uuid.uuid4().hex}"
     spec = importlib.util.spec_from_file_location(module_name, ROOT / "app.py")
     module = importlib.util.module_from_spec(spec)
+    module.__spec__ = spec
     sys.modules[module_name] = module
     loader = spec.loader
     assert loader is not None


### PR DESCRIPTION
## Summary
- gate the pamphlet bootstrap sequence with a persistent sentinel so migrations and seeding only run once even when multiple Gunicorn workers start concurrently
- require an optional `ADMIN_TOKEN` header for `/ops/backup/pamphlets`, surface per-city pamphlet counts with `Cache-Control: no-store` on `/readyz`, and document the new environment flag
- extend the storage helper and regression tests to cover the new counting helper and restart behaviour, updating the test harness so reload simulations work reliably

> **Note:** Please attach a Persistent Disk to the Render service and mount it at `/var/data` so the new storage layout is durable.

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_pamphlet_persistence.py tests/test_readyz_pamphlets.py`
- `pytest` *(fails: several unrelated assertion expectations in existing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3fc929d8832ca0137d6433acd636