### PR TITLE
Stabilize readyz tests and align pamphlet prompt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release Checks
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  smoke-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run targeted tests
+        run: |
+          pytest \
+            tests/test_readyz.py \
+            tests/test_readyz_endpoint.py \
+            tests/test_readyz_pamphlets.py \
+            tests/test_entries_minlen_e2e.py \
+            tests/test_pamphlet.py \
+            tests/test_pamphlet_answer_style.py \
+            tests/test_pamphlet_answer_style_fixed.py \
+            tests/test_pamphlet_fallback.py \
+            tests/test_pamphlet_persistence.py \
+            tests/test_city_prompt_only_in_pamphlet.py \
+            tests/test_rate_storage_env.py

--- a/coreapp/responders/pamphlet.py
+++ b/coreapp/responders/pamphlet.py
@@ -13,6 +13,9 @@ from coreapp.search.pamphlet_index import (
 )
 
 
+CITY_PROMPT = "どの市町の資料ですか？"
+
+
 CITY_CHOICES: List[Dict[str, str]] = [
     {"key": "goto", "label": "五島市"},
     {"key": "shinkamigoto", "label": "新上五島町"},
@@ -107,7 +110,7 @@ class PamphletResponder:
             quick, web = self._choices_payload()
             return PamphletResponderResult(
                 kind="ask_city",
-                message="市町を選択してください。",
+                message=CITY_PROMPT,
                 quick_replies=quick,
                 web_buttons=web,
             )
@@ -152,4 +155,9 @@ class PamphletResponder:
         )
 
 
-__all__ = ["CITY_CHOICES", "PamphletResponder", "PamphletResponderResult"]
+__all__ = [
+    "CITY_CHOICES",
+    "CITY_PROMPT",
+    "PamphletResponder",
+    "PamphletResponderResult",
+]

--- a/scripts/rollback_to_tag.sh
+++ b/scripts/rollback_to_tag.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <tag>" >&2
+  exit 1
+fi
+
+TAG_NAME="$1"
+
+git fetch --tags
+
+if ! git rev-parse "${TAG_NAME}" >/dev/null 2>&1; then
+  echo "Tag ${TAG_NAME} does not exist" >&2
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+echo "Resetting ${CURRENT_BRANCH} to ${TAG_NAME}" >&2
+git reset --hard "${TAG_NAME}"
+
+echo "Local branch ${CURRENT_BRANCH} now matches ${TAG_NAME}."
+echo "Push the rollback with: git push --force-with-lease origin ${CURRENT_BRANCH}" >&2

--- a/scripts/smoke_release.py
+++ b/scripts/smoke_release.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Release smoke-check helper.
+
+The script exercises the critical readiness endpoints and a handful of
+representative user journeys so that production rollouts can be verified
+quickly.  It exits with a non-zero status on the first failure.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from typing import Any, Dict, Tuple
+
+import requests
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _log_section(title: str, payload: Dict[str, Any]) -> None:
+    logging.info("%s:\n%s", title, json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def _ask(
+    session: requests.Session,
+    base_url: str,
+    question: str,
+    *,
+    timeout: float,
+    require_hit: bool,
+    allow_safe: bool,
+) -> Tuple[requests.Response, Dict[str, Any]]:
+    url = f"{base_url}/ask"
+    logging.info("POST %s question=%s", url, question)
+    response = session.post(url, json={"question": question}, timeout=timeout)
+    if response.status_code not in (200, 202):
+        raise RuntimeError(f"/ask returned {response.status_code} for question {question!r}")
+
+    payload = response.json()
+    if require_hit and response.status_code != 200:
+        raise RuntimeError(f"Expected hit response for {question!r}, got status {response.status_code}")
+    if not allow_safe and response.status_code == 202:
+        raise RuntimeError(f"Unexpected SAFE_MODE response for {question!r}")
+    return response, payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run release smoke checks against the API")
+    parser.add_argument("--base-url", default="http://localhost:5000", help="Target service base URL")
+    parser.add_argument("--timeout", type=float, default=10.0, help="Request timeout in seconds")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+
+    base_url = args.base_url.rstrip("/")
+    session = requests.Session()
+
+    # 1) /healthz
+    health_url = f"{base_url}/healthz"
+    logging.info("GET %s", health_url)
+    health = session.get(health_url, timeout=args.timeout)
+    if health.status_code != 200:
+        raise RuntimeError(f"/healthz returned {health.status_code}")
+
+    # 2) /readyz
+    ready_url = f"{base_url}/readyz"
+    logging.info("GET %s", ready_url)
+    ready = session.get(ready_url, timeout=args.timeout)
+    if ready.status_code != 200:
+        raise RuntimeError(f"/readyz returned {ready.status_code}")
+
+    ready_payload = ready.json()
+    flags = ready_payload.get("details", {}).get("flags", {})
+    dirs = {
+        "data_base_dir": ready_payload.get("details", {}).get("data_base_dir"),
+        "pamphlet_base_dir": ready_payload.get("details", {}).get("pamphlet_base_dir"),
+    }
+    pamphlet_count = ready_payload.get("details", {}).get("pamphlet_count")
+    _log_section("readyz.flags", flags)
+    _log_section("readyz.dirs", dirs)
+    logging.info("pamphlet_count=%s", pamphlet_count)
+
+    safe_mode = _truthy(flags.get("SAFE_MODE"))
+
+    # 3) Smoke queries
+    weather_resp, weather_payload = _ask(
+        session,
+        base_url,
+        "天気",
+        timeout=args.timeout,
+        require_hit=True,
+        allow_safe=False,
+    )
+    logging.info("weather meta=%s", json.dumps(weather_payload.get("meta", {}), ensure_ascii=False))
+
+    entries_resp, entries_payload = _ask(
+        session,
+        base_url,
+        "教会",
+        timeout=args.timeout,
+        require_hit=True,
+        allow_safe=False,
+    )
+    if not entries_payload.get("answer"):
+        raise RuntimeError("Entries query returned an empty answer")
+    logging.info(
+        "entries meta=%s",
+        json.dumps(entries_payload.get("meta", {}), ensure_ascii=False),
+    )
+
+    pamphlet_resp, pamphlet_payload = _ask(
+        session,
+        base_url,
+        "パンフレット",
+        timeout=args.timeout,
+        require_hit=not safe_mode,
+        allow_safe=safe_mode,
+    )
+    logging.info(
+        "pamphlet status=%s meta=%s",
+        pamphlet_resp.status_code,
+        json.dumps(pamphlet_payload.get("meta", {}), ensure_ascii=False),
+    )
+    if not safe_mode and not pamphlet_payload.get("answer"):
+        raise RuntimeError("Pamphlet query returned an empty answer outside SAFE_MODE")
+
+    fallback_resp, fallback_payload = _ask(
+        session,
+        base_url,
+        "存在しないメニューです",
+        timeout=args.timeout,
+        require_hit=False,
+        allow_safe=True,
+    )
+    logging.info(
+        "fallback status=%s meta=%s",
+        fallback_resp.status_code,
+        json.dumps(fallback_payload.get("meta", {}), ensure_ascii=False),
+    )
+
+    logging.info("Smoke checks completed successfully")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <tag> [ref]" >&2
+  exit 1
+fi
+
+TAG_NAME="$1"
+REF="${2:-}"
+
+if git rev-parse "${TAG_NAME}" >/dev/null 2>&1; then
+  echo "Tag ${TAG_NAME} already exists" >&2
+  exit 1
+fi
+
+git fetch --tags
+
+if [[ -n "${REF}" ]]; then
+  git tag -a "${TAG_NAME}" "${REF}" -m "Release ${TAG_NAME}"
+else
+  git tag -a "${TAG_NAME}" -m "Release ${TAG_NAME}"
+fi
+
+git push origin "${TAG_NAME}"

--- a/services/tourism_search.py
+++ b/services/tourism_search.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
+from coreapp.search.query_limits import min_query_chars, normalize_for_length
+
 from . import pamphlet_search
 
 
@@ -242,6 +244,9 @@ def search(
     limit: int = 3,
 ) -> List[ScoredEntry]:
     """Return scored tourism entries for ``query`` limited to ``limit`` hits."""
+
+    if len(normalize_for_length(query)) < min_query_chars():
+        return []
 
     tokens = _tokenize(query)
     if not tokens:

--- a/tests/test_city_prompt_only_in_pamphlet.py
+++ b/tests/test_city_prompt_only_in_pamphlet.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from coreapp.responders.pamphlet import CITY_PROMPT
+
 pytest.importorskip("flask")
 pytest.importorskip("werkzeug")
 pytest.importorskip("dotenv")
@@ -56,7 +58,7 @@ def test_city_prompt_only_in_pamphlet(monkeypatch, tmp_path):
 
         prompt, hit_prompt, _ = app_module._answer_from_entries_min("遣唐使の時代", user_id="user1")
         assert hit_prompt is True
-        assert "どの市町の資料ですか？" in prompt
+        assert CITY_PROMPT in prompt
 
         summary, hit_summary, _ = app_module._answer_from_entries_min("五島市", user_id="user1")
         assert hit_summary is True

--- a/tests/test_pamphlet_answer_style_fixed.py
+++ b/tests/test_pamphlet_answer_style_fixed.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from coreapp.responders.pamphlet import CITY_PROMPT
+
 pytest.importorskip("flask")
 pytest.importorskip("werkzeug")
 pytest.importorskip("dotenv")
@@ -59,7 +61,7 @@ def test_pamphlet_answer_style_fixed(monkeypatch, tmp_path):
 
         prompt, hit_prompt, _ = app_module._answer_from_entries_min("遣唐使について知りたい", user_id="user2")
         assert hit_prompt is True
-        assert "どの市町の資料ですか？" in prompt
+        assert CITY_PROMPT in prompt
 
         answer, hit_answer, _ = app_module._answer_from_entries_min("五島市", user_id="user2")
         assert hit_answer is True

--- a/tests/test_rate_storage_env.py
+++ b/tests/test_rate_storage_env.py
@@ -1,0 +1,31 @@
+from tests.utils import load_test_app
+
+
+def test_rate_storage_prefers_url(monkeypatch, tmp_path):
+    with load_test_app(
+        monkeypatch,
+        tmp_path,
+        extra_env={
+            "SECRET_KEY": "test",
+            "RATE_STORAGE_URL": "redis://url-primary/0",
+            "RATE_STORAGE_URI": "redis://legacy/0",
+        },
+    ) as module:
+        assert module.RATE_STORAGE_URL == "redis://url-primary/0"
+        assert module.app.config["RATE_STORAGE_URL"] == "redis://url-primary/0"
+        assert module.app.config["RATE_STORAGE_URI"] == "redis://url-primary/0"
+
+
+def test_rate_storage_falls_back_to_uri(monkeypatch, tmp_path):
+    with load_test_app(
+        monkeypatch,
+        tmp_path,
+        extra_env={
+            "SECRET_KEY": "test",
+            "RATE_STORAGE_URL": None,
+            "RATE_STORAGE_URI": "redis://legacy/1",
+        },
+    ) as module:
+        assert module.RATE_STORAGE_URL == "redis://legacy/1"
+        assert module.app.config["RATE_STORAGE_URL"] == "redis://legacy/1"
+        assert module.app.config["RATE_STORAGE_URI"] == "redis://legacy/1"

--- a/tests/test_readyz_endpoint.py
+++ b/tests/test_readyz_endpoint.py
@@ -18,6 +18,19 @@ def test_readyz_returns_expected_schema(monkeypatch, tmp_path):
         app = module.app
         client = app.test_client()
 
+        monkeypatch.setattr(
+            module,
+            "_describe_mount",
+            lambda path: {
+                "path": str(path),
+                "resolved_path": str(path),
+                "device": "tmpfs",
+                "mount_point": str(path),
+                "fs_type": "tmpfs",
+                "options": ["rw"],
+            },
+        )
+
         response = client.get("/readyz")
         assert response.status_code == 200
 
@@ -30,7 +43,11 @@ def test_readyz_returns_expected_schema(monkeypatch, tmp_path):
         assert details["data_base_dir"] == str(app.config["DATA_BASE_DIR"])
         assert details["pamphlet_base_dir"] == str(base_dir)
         assert details.get("pamphlet_count") == 0
+        assert details["fs_mount"]["device"] == "tmpfs"
+        assert details["fs_mount"]["mount_point"] == str(app.config["DATA_BASE_DIR"])
         flags = details.get("flags") or {}
         assert flags.get("MIN_QUERY_CHARS") == cfg.MIN_QUERY_CHARS
         assert flags.get("ENABLE_ENTRIES_2CHAR") == cfg.ENABLE_ENTRIES_2CHAR
         assert flags.get("EFFECTIVE_MIN_QUERY_CHARS") == cfg.MIN_QUERY_CHARS
+        assert flags.get("DATA_BASE_DIR") == str(app.config["DATA_BASE_DIR"])
+        assert flags.get("PAMPHLET_BASE_DIR") == str(base_dir)


### PR DESCRIPTION
## Summary
- expose deployment flags and filesystem details on `/readyz` and add a rate limit storage fallback
- centralise the tourism query minimum length around `MIN_QUERY_CHARS` and cover the behaviour with tests
- add release automation helpers including the smoke script, workflow, and tag/rollback utilities
- stabilize the `/readyz` regression tests by mocking the writable probe and asserting the JSON response metadata
- share a `CITY_PROMPT` constant for the pamphlet responder and update callers and tests to use it

## Testing
- pytest tests/test_readyz.py tests/test_readyz_endpoint.py tests/test_entries_minlen_e2e.py tests/test_rate_storage_env.py *(fails: missing flask dependency in container)*
- pytest tests/test_readyz.py tests/test_pamphlet_answer_style_fixed.py tests/test_city_prompt_only_in_pamphlet.py *(skipped: flask dependency unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddaf57fdcc832c90818e6136f4a52d